### PR TITLE
Update menu styles so they position nicely within the new wicket grid

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SectionColumnHeaderPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SectionColumnHeaderPanel.html
@@ -4,7 +4,7 @@
 <body>
 <wicket:panel>
 	
-	<div wicket:id="title"></div>
+	<div wicket:id="title" class="title"></div>
 	
 	<select wicket:id="sectionList">
   		<option value="1">Section 1</option>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
@@ -4,7 +4,7 @@
 <body>
 <wicket:panel>
 	
-	<div wicket:id="title"></div>
+	<div wicket:id="title" class="title"></div>
 	
 	<select wicket:id="sortOrderList">
   		<option value="1">Last Name</option>

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -26,49 +26,40 @@
   height: 2em;
   line-height: 2em;
 }
-#gradebookGrades .imxt-empty-row td {
+#gradebookGrades td {
   height: 0px;
 }
  
  /* Table Header */
-#gradebookGrades .imxt-head th {
+#gradebookGrades th {
   vertical-align: top;
   background: #FAFAFA;
   text-shadow: 1px 1px 0 #FFF;
+  font-weight: normal;
 }
-#gradebookGrades .imxt-head .average,
-#gradebookGrades .imxt-head .due-date {
+#gradebookGrades th .title {
+  font-weight: bold;
+}
+#gradebookGrades th .average,
+#gradebookGrades th .due-date {
   font-size: 0.9em;
   color: #999;
 }
-table.imxt-head th a.imxt-handle {
-  max-height: 100%;
-}
 
 /* Dropdown Menus */
-div.imxt-nowrap div, div.imxt-nowrap,
-div.imxt-head-container2,
-table.imxt-head th div.imxt-a,
-table.imxt-head th div.imxt-b,
-table.imxt-body td {
-  overflow: visible;
-}
-table.imxt-head th div.imxt-a {
-  position: inherit;
-}
 #gradebookGrades th, 
 #gradebookGrades td {
   position: relative;
 }
 #gradebookGrades td .btn-group {
   position: absolute;
-  bottom: 1px;
-  right: 6px;
+  bottom: 0;
+  right: 0;
 }
 #gradebookGrades th .btn-group {
   position: absolute;
-  right: 10px;
-  bottom: initial;
+  right: 0;
+  bottom: 0;
 }
 #gradebookGrades .btn.dropdown-toggle {
   padding: 0 8px;


### PR DESCRIPTION
Hey @steveswinsburg. I've cleaned up the styles to match the new grid.  I tried to add a css class 'title' to the column headers where possible.  However, I wasn't sure how to do that for the Course Grade column.. I'm sure there's a trick I'm missing!  It'd be great if we can keep the markup consistent between columns and headers to keep the CSS/Javascript from getting crazy ;) 
