### PR TITLE
Add extra params to the AjaxEditableLabel

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -3,6 +3,7 @@ package org.sakaiproject.gradebookng.tool.pages;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
@@ -93,7 +94,8 @@ public class GradebookPage extends BasePage {
 			public void populateItem(Item cellItem, String componentId, IModel rowModel) {
 				StudentGradeInfo studentGradeInfo = (StudentGradeInfo) rowModel.getObject();
 				cellItem.add(new StudentNameCellPanel(componentId, studentGradeInfo.getStudentName(), studentGradeInfo.getStudentEid()));
-
+				cellItem.add(new AttributeModifier("data-studentUuid", studentGradeInfo.getStudentUuid()));
+				cellItem.add(new AttributeModifier("class", "gb-student-cell"));
 			}
         	
         };
@@ -113,7 +115,12 @@ public class GradebookPage extends BasePage {
 					return panel;
 	        		
 	        	}
-	        	
+
+				@Override
+				public String getCssClass() {
+					return "gb-grade-item";
+				}
+
 				@Override
 				public void populateItem(Item cellItem, String componentId, IModel rowModel) {
 					cellItem.add(new EmptyPanel(componentId)); //TODO

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -97,7 +97,7 @@ public class GradebookPage extends BasePage {
 				cellItem.add(new AttributeModifier("data-studentUuid", studentGradeInfo.getStudentUuid()));
 				cellItem.add(new AttributeModifier("class", "gb-student-cell"));
 			}
-        	
+
         };
         
         cols.add(studentNameColumn);
@@ -115,11 +115,6 @@ public class GradebookPage extends BasePage {
 					return panel;
 	        		
 	        	}
-
-				@Override
-				public String getCssClass() {
-					return "gb-grade-item";
-				}
 
 				@Override
 				public void populateItem(Item cellItem, String componentId, IModel rowModel) {
@@ -149,6 +144,11 @@ public class GradebookPage extends BasePage {
             		AssignmentColumnHeaderPanel panel = new AssignmentColumnHeaderPanel(componentId, assignment);
     				return panel;
             	}
+
+						@Override
+						public String getCssClass() {
+							return "gb-grade-item-header";
+						}
             	
             	@Override
 				public void populateItem(Item cellItem, String componentId, IModel rowModel) {

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -9,6 +9,7 @@ import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.Model;
 import org.sakaiproject.service.gradebook.shared.Assignment;
+import org.apache.wicket.AttributeModifier;
 
 /**
  * 
@@ -34,7 +35,9 @@ public class AssignmentColumnHeaderPanel extends Panel {
 		add(averageGradeSection);
 		
 		add(new Label("dueDate", new Model<String>(getDueDate(assignment.getDueDate()))));
-		
+
+		add(new AttributeModifier("data-assignmentId", assignment.getId()));
+
 		//menu
 		//AjaxLink menu = new AjaxLink("menu", "http://google.com");
 		//link.add(new Label("menuLabel"));

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -12,6 +12,8 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.tool.model.GradeInfo;
 import org.sakaiproject.gradebookng.tool.model.StudentGradeInfo;
 
+import java.util.Map;
+
 /**
  * The panel for the cell of a grade item
  * 
@@ -59,14 +61,17 @@ public class GradeItemCellPanel extends Panel {
 			@Override
 			protected void updateLabelAjaxAttributes(AjaxRequestAttributes attributes) {
 				//when switching from editor to label
-				//attributes.getExtraParameters();
-				
+				Map<String,Object> extraParameters = attributes.getExtraParameters();
+				extraParameters.put("assignmentId", assignmentId);
+				extraParameters.put("studentUuid", studentGrades.getStudentUuid());
 			}
 			
 			@Override
 			protected void updateEditorAjaxAttributes(AjaxRequestAttributes attributes) {
 				//when switching from label to editor
-				//attributes.getExtraParameters();
+				Map<String,Object> extraParameters = attributes.getExtraParameters();
+				extraParameters.put("assignmentId", assignmentId);
+				extraParameters.put("studentUuid", studentGrades.getStudentUuid());
 			}
 			
 			

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -29,6 +29,15 @@ GradebookSpreadsheet.prototype.setupWicketAJAXEventHandler = function() {
       self.getCellModel($element.closest(".gb-cell")).handleWicketEvent(jqEvent, element);
     }
   });
+
+  Wicket.Event.subscribe('/ajax/call/complete', function(jqEvent, attributes, jqXHR, errorThrown, textStatus) {
+    console.log("** '/ajax/call/complete'");
+    console.log(jqEvent);
+    console.log(attributes);
+    console.log(jqXHR);
+    console.log(errorThrown);
+    console.log(textStatus);
+  });
 };
 
 


### PR DESCRIPTION
Hi @steveswinsburg.

I've played around with adding studentUuid and assignmentId to the AjaxEditableLabel extra parameters. Works great :)  Now that we have those values, I've refactored the javascript to no longer rely on row and cell indexes to find the right cell.  I think this will becomehelpful when the rows and cells becomes reorderable and the javascript will now longer need to keep track of those changing indexes - we can now access the custom behaviour by asking the cell for its model `$("td").data("model")`. 

I've also changed the Ajax Wicket event we bind to - `/ajax/call/complete` - the new code grabs the studentUuid and assignmentId from the extra params and notifies the cell that it's ready to do stuff.  This might also come in handy when reacting to `/ajax/call/success` vs `/ajax/call/error` (validation errors?).

I've had to poke a few things into the Wicket elements around the place to provide some extra context.  You'll notice some extra `AttributeModifier`s around the place. Hope they look ok.

Thanks,
Payten
