### PR TITLE
Column ordering fixes

### DIFF
--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -328,6 +328,13 @@ GradebookSpreadsheet.prototype.setupFixedTableHeader = function(reset) {
   }
 
   $(document).off("scroll", positionFixedHeader).on("scroll", positionFixedHeader);
+
+  $fixedHeader.find("th").on("click", function(event) {
+    event.preventDefault();
+
+    $(document).scrollTop(self.$table.offset().top - 10);
+    self.$table.find("thead tr th").get($(this).index()).focus();
+  });
   positionFixedHeader();
 };
 

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -302,8 +302,13 @@ GradebookSpreadsheet.prototype.getHeader = function() {
 };
 
 
-GradebookSpreadsheet.prototype.setupFixedTableHeader = function() {
+GradebookSpreadsheet.prototype.setupFixedTableHeader = function(reset) {
   var self = this;
+
+  if (reset) {
+    // delete the existing header and initialize a new one
+    self.$spreadsheet.find(".gb-fixed-header-table").remove();
+  };
 
   var $header = self.$table.find("thead", "tr");
   var $fixedHeader = $("<table>").attr("class", self.$table.attr("class")).addClass("gb-fixed-header-table").hide();
@@ -322,11 +327,15 @@ GradebookSpreadsheet.prototype.setupFixedTableHeader = function() {
     }
   }
 
-  $(document).on("scroll", function() {
-    positionFixedHeader();
-  });
+  $(document).off("scroll", positionFixedHeader).on("scroll", positionFixedHeader);
   positionFixedHeader();
 };
+
+
+GradebookSpreadsheet.prototype.refreshFixedTableHeader = function() {
+  this.setupFixedTableHeader(true);
+};
+
 
 GradebookSpreadsheet.prototype.setupFixedStudentColumn = function() {
   var self = this;
@@ -409,6 +418,9 @@ GradebookSpreadsheet.prototype.setupColumnDragAndDrop = function() {
       GradebookAPI.updateAssignmentOrder(self.$table.data("siteid"),
                                          $header.data("model").columnKey,
                                          order);
+
+      // refresh the fixed header
+      self.refreshFixedTableHeader(true)
     }
   });
 };

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -146,6 +146,15 @@
   font-family:"gradebook-icons";
   content: '\f0c9';
 }
+#gradebookGrades .gb-fixed-header-table .gb-grade-item-drag-handle {
+  cursor: pointer;
+}
+#gradebookGrades .gb-fixed-header-table .gb-grade-item-drag-handle:before {
+  content: '\f062';
+}
+#gradebookGrades .gb-fixed-header-table .btn-group {
+  visibility: hidden;
+}
 /* Wicket Overrides */
 div.wicket-modal div.w_content_3 {
 	border: none; /** don't want border wrapping content inside the modal **/


### PR DESCRIPTION
Hi @steveswinsburg,

As mentioned, there were a few issues with the fixed header after adding the sorting behaviour.

There are two patches..
1. Refresh the cloned fixed header after a reorder so it remains in sync.  
2. Disable the menu and drag link in the cloned fixed header (as the javascript events are not bound to those versions of the links).  Instead clicking on the cloned header cell will return focus to the real header cell with all the active actions.  I've added some CSS / icons to make that a little clearer to user (hopefully).
