### PR TITLE
Fix student popup not displaying and proxy through clicks from the fixed cells to their original counterpart

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.html
@@ -31,7 +31,7 @@
 	    	<span class="caret"></span>
 	    </a>
 	    <ul class="dropdown-menu dropdown-menu-right">
-	   		<li><a tabindex="-1" href="#">Edit Item Details</a></li>
+	   		<li><a href="#">Edit Item Details</a></li>
 	    </ul>
     </div>
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
@@ -12,8 +12,8 @@
 	    	<span class="caret"></span>
 	    </a>
 	    <ul class="dropdown-menu dropdown-menu-right">
-	   		<li><a tabindex="-1" href="#">Grade Log</a></li>
-			<li><a tabindex="-1" href="#">View / Edit Comments</a></li>
+	   		<li><a href="#">Grade Log</a></li>
+			<li><a href="#">View / Edit Comments</a></li>
 	    </ul>
     </div>
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
@@ -22,8 +22,8 @@
 	    	<span class="caret"></span>
 	    </a>
 	    <ul class="dropdown-menu dropdown-menu-right">
-	   		<!-- <li><a tabindex="1" href="#">Sort by Last Name</a></li> -->
-	   		<li><a tabindex="2" href="#">Sort by First Name</a></li>
+	   		<!-- <li><a href="#">Sort by Last Name</a></li> -->
+	   		<li><a href="#">Sort by First Name</a></li>
 	    </ul>
     </div>
 	

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -346,8 +346,11 @@ GradebookSpreadsheet.prototype.setupFixedTableHeader = function(reset) {
     $(document).scrollTop(self.$table.offset().top - 10);
     var $target = $(self.$table.find("thead tr th").get($(this).index()));
 
-    // proxy through the event to start up a drag action
-    $target.trigger(event);
+    // attempt to proxy to elements in the original cell
+    if (!self.proxyEventToElementsInOriginalCell(event, $target)) {
+      // if false, proxy through the event to start up a drag action
+      $target.trigger(event); 
+    }
   });
   positionFixedHeader();
 };
@@ -466,7 +469,13 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
     event.preventDefault();
     $(document).scrollTop(self.$table.offset().top - 10);
     self.$spreadsheet.scrollLeft(0);
-    self.$table.find("thead tr th").get($(this).index()).focus();
+    var $targetCell = $(self.$table.find("thead tr th").get($(this).index()));
+
+    // attempt to proxy to elements in the original cell
+    if (!self.proxyEventToElementsInOriginalCell(event, $targetCell)) {
+      // otherwise just focus the original cell
+      $targetCell.focus();
+    }
   });
 
   // Clicks on the fixed column return you to the real column cell
@@ -477,6 +486,22 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
     var rowIndex = $(this).closest("tr").index();
     $(self.$table.find("tbody tr").get(rowIndex)).find("td").get(cellIndex).focus();
   });
+};
+
+
+GradebookSpreadsheet.prototype.proxyEventToElementsInOriginalCell = function(event, $originalCell) {
+    if (event.target.id) {
+      var $targetElement = $originalCell.find("#"+event.target.id);
+      if ($targetElement.length > 0) {
+        $targetElement.focus().trigger("click");
+        return true;
+      }
+    } else if ($(event.target).is("a.btn.dropdown-toggle")) {
+      $originalCell.find("a.btn.dropdown-toggle").focus().trigger("click");
+      return true;
+    }
+
+    return false;
 };
 
 

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -162,9 +162,6 @@
 #gradebookGrades .gb-fixed-columns-table.table-hover tr.hovered {
   background-color: #f5f5f5 !important;
 }
-#gradebookGrades .gb-fixed-header-table .btn-group {
-  visibility: hidden;
-}
 /* Fix ghosting of the dragtable helper */
 #gradebookGrades .dragtable-sortable {
   z-index: 10;


### PR DESCRIPTION
The student popup wasn't working because a duplicate link in the fixed column was stealing the javascript event because it had the same ID. To fix, all cells in the fixed headers/columns are cloned via a new method that strips out the IDs and stores them for later. Also introduced a javascript method that attempts to proxy any clicks on the fixed header/column back to the elements within the original cells.

And removed some tabindexes that were changing the natural keyboard navigation flow.
