### PR TITLE
Fix javascript error when entering cell edit mode

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -108,8 +108,8 @@ public class GradebookPage extends BasePage {
 				modelData.put("sortType", GbStudentSortType.LAST_NAME); //TODO this needs to come from somewhere, prefs maybe
 				
 				cellItem.add(new StudentNameCellPanel(componentId, Model.ofMap(modelData)));
-				//cellItem.add(new AttributeModifier("data-studentUuid", studentGradeInfo.getStudentUuid()));
-				//cellItem.add(new AttributeModifier("class", "gb-student-cell"));
+				cellItem.add(new AttributeModifier("data-studentUuid", studentGradeInfo.getStudentUuid()));
+				cellItem.add(new AttributeModifier("class", "gb-student-cell"));
 			}
 
         };


### PR DESCRIPTION
Hiya @steveswinsburg - any reason why those lines needed to be commented out?  The Javascript unfortunately relies on that `data-studentUuid` so it can identify the target cell when handling the Wicket  AJAX events :tired_face: 
