### PR TITLE
Clean up Wicket/Bootstrap dialogs

### DIFF
--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -251,5 +251,20 @@
 }
 /* Wicket Overrides */
 div.wicket-modal div.w_content_3 {
-	border: none; /** don't want border wrapping content inside the modal **/
+  border: none; /** don't want border wrapping content inside the modal **/
+}
+div.wicket-mask-dark {
+  /* make the modal background darker */
+  opacity: 0.95;
+  filter: alpha(opacity=95);
+}
+div.wicket-modal div.w_content_container {
+  /* give wicket model content some padding */
+  padding: 0 20px 20px;
+}
+div.wicket-modal div.w_content_container > div > h2:first-child,
+div.wicket-modal div.w_content_container > div > form > h2:first-child {
+  /* remove the large morpheus top padding and margin from the first header element */
+  padding-top: 0;
+  margin-top: 0;
 }


### PR DESCRIPTION
Hi @steveswinsburg.  In response to you skype message, I've added some CSS overrides to clean the up the wicket bootstrap dialogs and also darken the modal background so the content behind is not readable.  The large top padding is due to the Morpheus heading element styles... but I've added overrides to drop them when in that dialog context.
