### PR TITLE
Group by Category

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -75,6 +75,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 		add(new WebMarkupContainer("notReleasedFlag").setVisible(!assignment.isReleased()));
 
 		add(new AttributeModifier("data-assignmentId", assignment.getId()));
+		add(new AttributeModifier("data-category", assignment.getCategoryName()));
 
 		//menu
 		//AjaxLink menu = new AjaxLink("menu", "http://google.com");

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -99,8 +99,31 @@
   min-height: 40px;
 }
 /* Distinguish Fixed Columns */
-#gradebookGrades table tr > :nth-child(2) {
+#gradebookGrades table thead tr > th:nth-child(2),
+#gradebookGrades table tbody tr > td:nth-child(2) {
   border-right: 2px solid #AAA;
+}
+/* Categories */
+#gradebookGrades table tr.gb-categories-row td {
+  height: 30px;
+  line-height: 16px;
+  font-size: 16px;
+}
+#gradebookGrades table tr.gb-categories-row > td:nth-child(1) {
+  border-right: 2px solid #AAA;
+}
+#gradebookGrades .gb-categories-row td {
+  text-align: center;
+  background: #e6e6e6;
+}
+#gradebookGrades.gb-grouped-by-category .dragtable-sortable {
+  margin-top: 30px;
+}
+#gradebookGrades .gb-fixed-column-headers-table .gb-categories-row {
+  display: none;
+}
+#gradebookGrades.gb-grouped-by-category .gb-fixed-column-headers-table .gb-categories-row {
+  display: table-row;
 }
 /* Table Cells */
 #gradebookGrades tbody td.gb-cell {
@@ -144,7 +167,6 @@
 #gradebookGrades .gb-fixed-columns-table,
 #gradebookGrades .gb-fixed-column-headers-table {
   border-right: none;
-  border-left-width: 3px;
 }
 #gradebookGrades .gb-fixed-column-headers-table {
   z-index: 30;
@@ -259,10 +281,10 @@ div.wicket-mask-dark {
   filter: alpha(opacity=95);
 }
 div.wicket-mask-transparent {
-  	/* make the modal background darker, back to the original 10% opacity */
-	opacity: 0.1; 
-	background-color: black; 
-	filter: alpha(opacity=10); 
+  /* make the modal background darker, back to the original 10% opacity */
+  opacity: 0.1; 
+  background-color: black; 
+  filter: alpha(opacity=10); 
 }
 div.wicket-modal div.w_content_container {
   /* give wicket model content some padding */
@@ -277,7 +299,7 @@ div.wicket-modal div.w_content_container > div > form > h2:first-child {
 
 /* style applied to a div for a Wicket FeedbackPanel, but removes the list styles and just make it bold */
 .feedbackPanel {
-	list-style-type: none;
-	margin-left: 0;
-	padding-left: 0;
+  list-style-type: none;
+  margin-left: 0;
+  padding-left: 0;
 }


### PR DESCRIPTION
Add the grade item's category to their header cell as a data attribute.

Hook up the "Group by Category" button so that is actually groups by category.

Sort the categories by alpha but show uncategorized at the end.  If the Gradebook doesn't have any categories, then all items will be grouped under uncategorized.

Ensure the fixed headers take into account the new Category row.

Introduce Gradebook.prototype.find which searches for matching elements on the this..

Ensure drag and drop works with categories.  When grouped, the drop scope is limited to the cells within the category.  Also when dragging an item, store this cell on the spreadsheet context so we know the currently 'activeCell' - the dragtable doesn't know the original cell (only the drag handle) so we need it to determine the category scope of the active cell.

Store the sort order on the spreadsheet so we can reorder the columns back to their extected order as we jump in and out of the grouped by category view.

Store 'flat' ordering and also the categorised ordering as they are expected to be stored as two different orders i.e. each item has two order indexes, one for flat, one when categorised.  Currently we only store the 'flat' order, but it has been requested we store both orders in the database.
