### PR TITLE
Introduce Show/Hide Grade item toolbar panel

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -23,6 +23,8 @@ label.gradeitem.counted=Gradebook Item is included in the course grade calculati
 label.gradeitem.notcounted=Gradebook  Item is not included in the course grade calculation
 label.gradeitem.extracredit=This is an Extra Credit item
 label.toolbar.gradeitemsummary=Viewing <span class='gb-item-summary-counts'><span class='visible'>{0}</span> of <span class='total'>{1}</span></span> items
+label.toolbar.gradeitemshowall=Show All
+label.toolbar.gradeitemhideall=Hide All
 
 column.header.section = Section
 column.header.students = Students

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -49,6 +49,8 @@
       <table wicket:id="table" id="gradebookGradesTable" class="table-striped table-bordered table-hover"></table>
     </div>
   </form>
+
+  <div wicket:id="gradeItemsTogglePanel" id="gradeItemsTogglePanel" style="display: none;"/>
 </wicket:extend>
 
 </body>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -37,6 +37,7 @@ import org.sakaiproject.gradebookng.tool.panels.AssignmentColumnHeaderPanel;
 import org.sakaiproject.gradebookng.tool.panels.GradeItemCellPanel;
 import org.sakaiproject.gradebookng.tool.panels.StudentNameCellPanel;
 import org.sakaiproject.gradebookng.tool.panels.StudentNameColumnHeaderPanel;
+import org.sakaiproject.gradebookng.tool.panels.ToggleGradeItemsToolbarPanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
 /**
@@ -191,6 +192,8 @@ public class GradebookPage extends BasePage {
         groupFilter.setDefaultModelObject(groups.get(0)); //TODO update this
         groupFilter.setNullValid(false);
         form.add(groupFilter);
+
+        add(new ToggleGradeItemsToolbarPanel("gradeItemsTogglePanel", assignments));
 	}
 	
 	/**

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd" >
+
+<body>
+<wicket:panel>
+
+<div id="gradeItemsToolbarItemPanel">
+  <a href="javascript:void(0)" id="hideAllGradeItems"><span wicket:message="value:label.toolbar.gradeitemhideall">Hide All</span></a>
+  <a href="javascript:void(0)" id="showAllGradeItems"><span wicket:message="value:label.toolbar.gradeitemshowall">Show All</span></a>
+  <div wicket:id="categoriesList" class="gradebook-item-filter-group">
+    <div class="gradebook-item-category-filter">
+      <label tabindex="0">
+        <span wicket:id="category"></span>
+        <span class="gradebook-item-category-filter-signal"></span>
+        <input wicket:id="categoryCheckbox" type="checkbox">
+      </label>
+      <a class="context-menu-toggle" href="javascript:void(0);"></a>
+    </div>
+    <div wicket:id="assignmentsForCategory" class="gradebook-item-filter">
+      <label tabindex="0">
+        <span wicket:id="assignmentTitle"></span>
+        <span class="gradebook-item-category-filter-signal"></span>
+        <input wicket:id="assignmentCheckbox" type="checkbox">
+      </label>
+      <a class="context-menu-toggle" href="javascript:void(0);"></a>
+    </div>
+  </div>
+</div>
+
+</wicket:panel>
+</body>
+</html>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
@@ -1,0 +1,80 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.repeater.Item;
+import org.apache.wicket.markup.repeater.RepeatingView;
+import org.apache.wicket.markup.repeater.data.ListDataProvider;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.xmlbeans.impl.piccolo.xml.Piccolo;
+import org.sakaiproject.gradebookng.tool.model.GradeInfo;
+import org.sakaiproject.service.gradebook.shared.Assignment;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Iterator;
+
+public class ToggleGradeItemsToolbarPanel extends Panel {
+
+  private static final long serialVersionUID = 1L;
+
+  public ToggleGradeItemsToolbarPanel(String id, final List<Assignment> assignments) {
+    super(id);
+
+    final List<String> categories = new ArrayList<String>();
+    final Map<String, List<Assignment>> categoriesToAssignments = new HashMap<String, List<Assignment>>();
+    
+    Iterator<Assignment> assignmentIterator = assignments.iterator();
+    while (assignmentIterator.hasNext()) {
+      Assignment assignment = assignmentIterator.next();
+      String category = assignment.getCategoryName() == null ? "Uncategorized" : assignment.getCategoryName();
+      
+      if (!categoriesToAssignments.containsKey(category)) {
+        categories.add(category);
+        categoriesToAssignments.put(category, new ArrayList<Assignment>());
+      }
+
+      categoriesToAssignments.get(category).add(assignment);
+    }
+
+    Collections.sort(categories);
+
+    add(new ListView<String>("categoriesList", categories) {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      protected void populateItem(ListItem<String> categoryItem) {
+        String category = categoryItem.getModelObject();
+        
+        categoryItem.add(new Label("category", category));
+        CheckBox categoryCheckbox = new CheckBox("categoryCheckbox");
+        categoryCheckbox.add(new AttributeModifier("value", category));
+        categoryCheckbox.add(new AttributeModifier("checked", "checked"));
+        categoryItem.add(categoryCheckbox);
+
+        categoryItem.add(new ListView<Assignment>("assignmentsForCategory", categoriesToAssignments.get(category)) {
+          private static final long serialVersionUID = 1L;
+
+          @Override
+          protected void populateItem(ListItem<Assignment> assignmentItem) {
+            Assignment assignment = assignmentItem.getModelObject();
+            
+            assignmentItem.add(new Label("assignmentTitle", assignment.getName()));
+            CheckBox assignmentCheckbox = new CheckBox("assignmentCheckbox");
+            assignmentCheckbox.add(new AttributeModifier("value", assignment.getId().toString()));
+            assignmentCheckbox.add(new AttributeModifier("data-colidx", assignments.indexOf(assignment)));
+            assignmentCheckbox.add(new AttributeModifier("checked", "checked"));
+            assignmentItem.add(assignmentCheckbox);
+          }
+        });
+      }
+    });
+  }
+}

--- a/tool/src/webapp/scripts/lib/jquery.dragtable.js
+++ b/tool/src/webapp/scripts/lib/jquery.dragtable.js
@@ -108,13 +108,14 @@
      */
     _restoreState: function(persistObj) {
       for (var n in persistObj) {
-        this.originalTable.startIndex = $('#' + n).closest('th').prevAll().size() + 1;
+        this.originalTable.startIndex = $('#' + n).closest('th').prevAll(':visible').size() + 1;
         this.originalTable.endIndex = parseInt(persistObj[n], 10) + 1;
         this._bubbleCols();
       }
     },
     // bubble the moved col left or right
     _bubbleCols: function() {
+      var _this = this;
       var i, j, col1, col2;
       var from = this.originalTable.startIndex;
       var to = this.originalTable.endIndex;
@@ -127,20 +128,20 @@
       }
       if (from < to) {
         for (i = from; i < to; i++) {
-          col1 = thtb.find('> tr > td:nth-child(' + i + ')')
-            .add(thtb.find('> tr > th:nth-child(' + i + ')'));
-          col2 = thtb.find('> tr > td:nth-child(' + (i + 1) + ')')
-            .add(thtb.find('> tr > th:nth-child(' + (i + 1) + ')'));
+          col1 = $(thtb.find('> tr > td:visible').get(i-1)) //:nth-child(' + i + ')'
+            .add(thtb.find('> tr > th:visible').get(i-1)); //:nth-child(' + i + ')')
+          col2 = $(thtb.find('> tr > td:visible').get(i)) //:nth-child(' + (i + 1) + ')'
+            .add(thtb.find('> tr > th:visible').get(i)); //:nth-child(' + (i + 1) + ')'
           for (j = 0; j < col1.length; j++) {
             swapNodes(col1[j], col2[j]);
           }
         }
       } else {
         for (i = from; i > to; i--) {
-          col1 = thtb.find('> tr > td:nth-child(' + i + ')')
-            .add(thtb.find('> tr > th:nth-child(' + i + ')'));
-          col2 = thtb.find('> tr > td:nth-child(' + (i - 1) + ')')
-            .add(thtb.find('> tr > th:nth-child(' + (i - 1) + ')'));
+          col1 = $(thtb.find('> tr > td:visible').get(i-1)) //:nth-child(' + i + ')'
+            .add(thtb.find('> tr > th:visible').get(i-1)); //:nth-child(' + i + ')')
+          col2 = $(thtb.find('> tr > td:visible').get(i-2)) //:nth-child(' + (i + 1) + ')'
+            .add(thtb.find('> tr > th:visible').get(i-2)); //:nth-child(' + (i + 1) + ')'
           for (j = 0; j < col1.length; j++) {
             swapNodes(col1[j], col2[j]);
           }
@@ -171,7 +172,7 @@
         _this.options.beforeReorganize(_this.originalTable, _this.sortableTable);
         // do reorganisation asynchronous
         // for chrome a little bit more than 1 ms because we want to force a rerender
-        _this.originalTable.endIndex = _this.sortableTable.movingRow.prevAll().size() + 1;
+        _this.originalTable.endIndex = _this.sortableTable.movingRow.prevAll(':visible').size() + 1;
         setTimeout(_this._rearrangeTableBackroundProcessing(), 50);
       };
     },
@@ -220,7 +221,7 @@
       if (this.options.excludeFooter) {
         thtb = thtb.not('tfoot');
       }
-      thtb.find('> tr > th').each(function(i, v) {
+      thtb.find('> tr > th:visible').each(function(i, v) {
         var w = $(this).outerWidth();
         widthArr.push(w);
         totalWidth += w;
@@ -234,14 +235,14 @@
 
       var sortableHtml = '<ul class="dragtable-sortable" style="position:absolute; width:' + totalWidth + 'px;">';
       // assemble the needed html
-      thtb.find('> tr > th').each(function(i, v) {
+      thtb.find('> tr > th:visible').each(function(i, v) {
         var width_li = $(this).outerWidth();
         sortableHtml += '<li style="width:' + width_li + 'px;">';
         sortableHtml += '<table ' + attrsString + '>';
-        var row = thtb.find('> tr > th:nth-child(' + (i + 1) + ')');
-        if (_this.options.maxMovingRows > 1) {
-          row = row.add(thtb.find('> tr > td:nth-child(' + (i + 1) + ')').slice(0, _this.options.maxMovingRows - 1));
-        }
+        var row = $(thtb.find('> tr > th:visible').get(i)); //:nth-child(' + (i + 1) + ')'
+        //if (_this.options.maxMovingRows > 1) {
+        //  row = row.add(thtb.find('> tr > td:visible:nth-child(' + (i + 1) + ')').slice(0, _this.options.maxMovingRows - 1));
+        //}
         row.each(function(j) {
           // TODO: May cause duplicate style-Attribute
           var row_content = $(this).clone().wrap('<div></div>').parent().html();
@@ -279,7 +280,7 @@
       });
 
       // assign start index
-      this.originalTable.startIndex = $(e.target).closest('th').prevAll().size() + 1;
+      this.originalTable.startIndex = $(e.target).closest('th').prevAll(':visible').size() + 1;
 
       this.options.beforeMoving(this.originalTable, this.sortableTable);
       // Start moving by delegating the original event to the new sortable table

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -112,6 +112,9 @@
 #gradebookGrades table tr.gb-categories-row > td:nth-child(1) {
   border-right: 2px solid #AAA;
 }
+#gradebookGrades table tr.gb-categories-row > td:nth-child(2) {
+  border-right: 1px solid #DDD;
+}
 #gradebookGrades .gb-categories-row td {
   text-align: center;
   background: #e6e6e6;
@@ -222,7 +225,7 @@
 #gradebookGradesToolbar {
   background: #FAFAFA;
   font-size: 0.8em;
-  overflow: hidden;
+  overflow: visible;
   padding: 0 0.4em;
   position: absolute;
   top: 0;
@@ -271,6 +274,91 @@
 #filterByGroup {
   line-height: 1em;
 }
+#gradebookGradesToolbar .gradebook-item-summary.warn-items-hidden .gb-item-summary-counts {
+  color: #CA7311;
+  font-weight: bold;
+}
+/* Toolbar - Show/Hide grade items */
+#gradebookGradesToolbar .gb-toggle-grade-items-panel {
+  position: absolute;
+  border: 1px solid #bdbdbd;
+  min-width: 200px;
+  min-height: 100px;
+  top: 25px;
+  background-color: #FFF;
+  box-shadow: 1px 1px 2px #AAA;
+  z-index: 40;
+} 
+#gradeItemsTogglePanel .hide-me {
+  display: none;
+}
+#gradeItemsTogglePanel input {
+  margin-left: 20px;
+  background-color: transparent;
+  position: absolute;
+  left: -100000px;
+}
+#gradeItemsTogglePanel label {
+  cursor: pointer;
+  display: block;
+  margin: 0;
+}
+#gradeItemsTogglePanel label:hover {
+  background-color: #FAFAFA;
+}
+#gradeItemsTogglePanel input:before {
+  height: 16px;
+  width: 16px;
+  display: inline-block;
+  content: "";
+}
+#gradeItemsTogglePanel .gradebook-item-category-filter label {
+  font-weight: bold;
+}
+#gradeItemsTogglePanel .gradebook-item-filter label {
+  font-weight: normal;
+}
+#gradeItemsTogglePanel .gradebook-item-category-filter .weighting {
+  font-weight: 200;
+  color: #999;
+}
+#gradeItemsTogglePanel .gradebook-item-category-filter-signal {
+  height: 1.2em;
+  width: 1.2em;
+  float: right;
+  margin-left: 20px;
+  border: 1px solid #EEE;
+  background-color: #EEE;
+  margin-top: 0.3em;
+}
+#gradeItemsTogglePanel .gradebook-item-category-filter,
+#gradeItemsTogglePanel .gradebook-item-filter {
+  clear: both;
+  margin-left: 10px;
+  position: relative;
+}
+#gradeItemsTogglePanel label {
+  margin-right: 24px;
+}
+#gradeItemsTogglePanel label.category-partial-filter .gradebook-item-category-filter-signal:before {
+  font-family: 'nyu-classes-icons';
+  content: '\e060';
+}
+#gradeItemsTogglePanel .gradebook-filter-partial-signal {
+  display: block;
+
+  border-left: 1.2em solid transparent;
+  border-right: 0px solid transparent;
+  border-bottom: 1.2em solid;
+  border-bottom-color: inherit;
+}
+#gradeItemsTogglePanel #showAllGradeItems,
+#gradeItemsTogglePanel #hideAllGradeItems {
+  float: right;
+  font-size: 0.9em;
+  margin: 0 5px 0;
+  border-bottom: none;
+}
 /* Wicket Overrides */
 div.wicket-modal div.w_content_3 {
   border: none; /** don't want border wrapping content inside the modal **/
@@ -296,7 +384,6 @@ div.wicket-modal div.w_content_container > div > form > h2:first-child {
   padding-top: 0;
   margin-top: 0;
 }
-
 /* style applied to a div for a Wicket FeedbackPanel, but removes the list styles and just make it bold */
 .feedbackPanel {
   list-style-type: none;


### PR DESCRIPTION
This PR introduces the display toggle of the grade item columns, including the google-style flag for partially visible categories.

The toolbar panel itself is generated with a new Wicket panel that builds a category-to-grade item map so the template can output the toolbar actions in a reasonable order.  New javascript grabs this panel and attaches javascript listeners to the checkboxes to handle the show/hide behaviour.  

I've also had to enhance the dragtable jQuery plugin so it can handle hidden columns - it didn't take into account hidden columns when calculating drag offsets.

PR also includes a fix for keyboard navigation when categories are visible.
