### PR TITLE
Fix keyboard navigation breaking after edit and do a little refactoring of Javascript

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -135,7 +135,7 @@ public class GradebookPage extends BasePage {
 
 				@Override
 				public String getCssClass() {
-					return "gb-grade-item-header";
+					return "gb-grade-item-column-cell";
 				}
             	
             	@Override

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
@@ -4,7 +4,7 @@
 <body>
 <wicket:panel>
 	
-	<div wicket:id="grade" class="gb-item-grade">34</div>
+	<div wicket:id="grade">34</div>
 	
 	<!--  from wicket bootstrap, needs to be sorted out -->
 	<div class="btn-group">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxEditableLabel;
 import org.apache.wicket.markup.html.basic.Label;
@@ -74,6 +75,7 @@ public class GradeItemCellPanel extends Panel {
 					//set original grade, once only
 					super.onInitialize();
 					this.originalGrade = this.getLabel().getDefaultModelObjectAsString();
+					this.addSpecialAttributes();
 				}
 				
 				@Override
@@ -135,6 +137,28 @@ public class GradeItemCellPanel extends Panel {
 					Map<String,Object> extraParameters = attributes.getExtraParameters();
 					extraParameters.put("assignmentId", assignmentId);
 					extraParameters.put("studentUuid", studentUuid);
+
+					AjaxCallListener myAjaxCallListener = new AjaxCallListener() {
+						@Override
+						public CharSequence getBeforeSendHandler(Component component) {
+							return "GradebookWicketEventProxy.updateLabel.handleBeforeSend('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, settings);";
+						}
+
+						@Override
+						public CharSequence getSuccessHandler(Component component) {
+							return "GradebookWicketEventProxy.updateLabel.handleSuccess('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, data, textStatus);";
+						}
+
+						@Override
+						public CharSequence getFailureHandler(Component component) {
+							return "GradebookWicketEventProxy.updateLabel.handleFailure('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, errorMessage, textStatus);";
+						}
+						@Override
+						public CharSequence getCompleteHandler(Component component) {
+							return "GradebookWicketEventProxy.updateLabel.handleComplete('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, textStatus);";
+						}
+					};
+					attributes.getAjaxCallListeners().add(myAjaxCallListener);
 				}
 				
 				@Override
@@ -143,16 +167,43 @@ public class GradeItemCellPanel extends Panel {
 					Map<String,Object> extraParameters = attributes.getExtraParameters();
 					extraParameters.put("assignmentId", assignmentId);
 					extraParameters.put("studentUuid", studentUuid);
+
+					AjaxCallListener myAjaxCallListener = new AjaxCallListener() {
+						@Override
+						public CharSequence getBeforeSendHandler(Component component) {
+							return "GradebookWicketEventProxy.updateEditor.handleBeforeSend('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, settings);";
+						}
+
+						@Override
+						public CharSequence getSuccessHandler(Component component) {
+							return "GradebookWicketEventProxy.updateEditor.handleSuccess('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, data, textStatus);";
+						}
+
+						@Override
+						public CharSequence getFailureHandler(Component component) {
+							return "GradebookWicketEventProxy.updateEditor.handleFailure('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, errorMessage, textStatus);";
+						}
+						@Override
+						public CharSequence getCompleteHandler(Component component) {
+							return "GradebookWicketEventProxy.updateEditor.handleComplete('" + getParentCellFor(component.getParent()).getMarkupId() + "', attrs, jqXHR, textStatus);";
+						}
+					};
+					attributes.getAjaxCallListeners().add(myAjaxCallListener);
 				}
 				
 				/* for setting the original grade at construction time */
 				public void setOriginalGrade(String grade) {
 					this.originalGrade = grade;
 				}
-				
-				
+
+				private void addSpecialAttributes() {
+					Component parentCell = getParentCellFor(this);
+					parentCell.add(new AttributeModifier("data-assignmentid", assignmentId));
+					parentCell.add(new AttributeModifier("data-studentuuid", studentUuid));
+					parentCell.add(new AttributeModifier("class", "gb-grade-item-cell"));
+				}
 			};
-			
+
 			gradeCell.setType(String.class);
 			
 			gradeCell.setOutputMarkupId(true);
@@ -175,17 +226,20 @@ public class GradeItemCellPanel extends Panel {
 	}
 	
 	private void markSuccessful(Component gradeCell) {
-		gradeCell.getParent().getParent().add(AttributeModifier.replace("class", "gb-grade-item-header gradeSaveSuccess"));
+		getParentCellFor(gradeCell).add(AttributeModifier.replace("class", "gb-grade-item-cell gradeSaveSuccess"));
 		//TODO attach a timeout here
 	}
 	
 	private void markError(Component gradeCell) {
-		gradeCell.getParent().getParent().add(AttributeModifier.replace("class", "gb-grade-item-header gradeSaveError"));
+		getParentCellFor(gradeCell).add(AttributeModifier.replace("class", "gb-grade-item-cell gradeSaveError"));
 	}
 	
 	private void markWarning(Component gradeCell) {
-		gradeCell.getParent().getParent().add(AttributeModifier.replace("class", "gb-grade-item-header gradeSaveWarning"));
+		getParentCellFor(gradeCell).add(AttributeModifier.replace("class", "gb-grade-item-cell gradeSaveWarning"));
+	}
+
+	private Component getParentCellFor(Component gradeCell) {
+		return gradeCell.getParent().getParent();
 	}
 	
-
 }

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -388,15 +388,9 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
 
   $fixedColumns.append($("<tbody>"));
 
-  var colWidths = [];
-  var totalWidth = 0;
-
   // populate the dummy header table
   $headers.each(function(i, origCell) {
     var $th = self._cloneCell($(origCell));
-    colWidths.push($(origCell).find(".gb-cell-inner").outerWidth());
-    $th.find(".gb-cell-inner").width(colWidths[i]);
-    totalWidth += colWidths[i];
     $fixedColumnsHeader.find("tr.gb-clone-row").append($th);
   });
 
@@ -406,7 +400,6 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
 
     $headers.each(function(i, origTh) {
       var $td = self._cloneCell($($(origRow).find("td").get(i)));
-      $td.find(".gb-cell-inner").width(colWidths[i]);
       $tr.append($td);
     });
 
@@ -812,17 +805,21 @@ var GradebookAbstractCell = {
   setupCell: function($cell) {
     this.$cell = $cell;
     $cell.data("model", this);
-    this.setupAbsolutePositioning();
+// Disable setupAbsolutePositioning as it slows down loading of the page
+// when there's a large dataset.  Replace this with some CSS to achieve
+// the same result.  Will leave the code in here just in case we need it
+// in the near future.
+//  setupAbsolutePositioning()
     this.makeCellTabbable();
   },
-  setupAbsolutePositioning: function() {
-    // as HTML tables don't normally allow position:absolute, innerWrap all cells
-    // with a div that provide the block level element to contain an absolutely
-    // positioned child node.
-    var $wrapDiv = $("<div>").addClass("gb-cell-inner");
-    $wrapDiv.height(this.$cell.height());
-    this.$cell.wrapInner($wrapDiv);
-  },
+//  setupAbsolutePositioning: function() {
+//    // as HTML tables don't normally allow position:absolute, innerWrap all cells
+//    // with a div that provide the block level element to contain an absolutely
+//    // positioned child node.
+//    var $wrapDiv = $("<div>").addClass("gb-cell-inner");
+//    $wrapDiv.height(this.$cell.height());
+//    this.$cell.wrapInner($wrapDiv);
+//  },
   makeCellTabbable: function() {
     var self = this;
     self.$cell.attr("tabindex", 0).

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -650,6 +650,10 @@ GradebookSpreadsheet.prototype._cloneCell = function($cell) {
     $(this).data("id", $(this).attr("id")).removeAttr("id");
   });
 
+  // set the width/height
+  $clone.height($cell.outerHeight());
+  $clone.width($cell.outerWidth());
+
   return $clone;
 };
 

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -86,8 +86,8 @@
   right: -5px;
 }
 #gradebookGrades .btn.dropdown-toggle {
-  padding: 0 8px;
-  line-height: 14px;
+  padding: 4px 8px;
+  line-height: 1em;
 }
 #gradebookGrades .btn.dropdown-toggle:hover,
 #gradebookGrades .btn.dropdown-toggle:focus {
@@ -132,19 +132,20 @@
 #gradebookGrades tbody td.gb-cell {
   height: 2.6em;
 }
-#gradebookGrades .gb-item-grade {
+#gradebookGrades .gb-grade-item-cell {
   text-align: center;
   white-space: nowrap;
 }
-#gradebookGrades .gb-item-grade span {
+#gradebookGrades .gb-grade-item-cell span {
   display: block;
 }
-#gradebookGrades .gb-item-grade input {
+#gradebookGrades .gb-grade-item-cell input {
   text-align: right;
   width: 40px;
   line-height: 1em;
+  display: inline;
 }
-#gradebookGrades .gb-item-grade .gb-out-of {
+#gradebookGrades .gb-grade-item-cell .gb-out-of {
   display: inline;
   padding-left: 6px;
   font-size: 0.9em;

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -35,7 +35,6 @@
 }
 #gradebookGrades th,
 #gradebookGrades td {
-  padding: 6px;
   min-width: 180px;
 }
 #gradebookGrades th input[type='text'],
@@ -74,16 +73,16 @@
 /* Dropdown Menus */
 #gradebookGrades td .btn-group {
   position: absolute;
-  bottom: -5px;
-  right: -5px;
+  bottom: 1px;
+  right: 1px;
 }
 #gradebookGrades .gb-cell {
   cursor: pointer;
 }
 #gradebookGrades th .btn-group {
   position: absolute;
-  bottom: -5px;
-  right: -5px;
+  bottom: 1px;
+  right: 1px;
 }
 #gradebookGrades .btn.dropdown-toggle {
   padding: 4px 8px;
@@ -151,11 +150,23 @@
   font-size: 0.9em;
   color: #999;
 }
-#gradebookGrades .gb-cell .gb-cell-inner {
+/* as HTML tables don't normally allow position:absolute, innerWrap all cells
+   with a div that provide the block level element to contain an absolutely
+   positioned child node. */
+#gradebookGrades thead th > span,
+#gradebookGrades tbody th > span,
+#gradebookGrades thead th > div,
+#gradebookGrades tbody td > div {
   width: 100%;
   position: relative;
-  height: auto; /* will be overriden by the javascript */
+  padding: 6px;
+  display: block;
 }
+#gradebookGrades thead th > span,
+#gradebookGrades tbody th > span {
+  min-height: 90px;
+}
+
 #gradebookGrades .gb-due-date {
   margin-bottom: 1.2em;
 }
@@ -200,7 +211,7 @@
 }
 #gradebookGrades .gb-grade-item-flags {
   position: absolute;
-  bottom: -8px;
+  bottom: 0;
   left: 0;
 }
 #gradebookGrades .gb-grade-item-flags span {

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -212,7 +212,7 @@
 #gradebookGrades .gb-grade-item-flags {
   position: absolute;
   bottom: 0;
-  left: 0;
+  left: 5px;
 }
 #gradebookGrades .gb-grade-item-flags span {
   margin-right: 4px;
@@ -439,4 +439,3 @@ ul.feedbackPanel {
 .gradeSaveWarning {
 	background-color: #fcf8e3 !important;
 }
-	


### PR DESCRIPTION
Refactor Javascript and some of the frontend Wicket code a little bit to ensure the grade item header cell has a CSS class of gb-grade-item-column-cell and the editable cell has a CSS class of gb-grade-item-cell.  Also refactor how the Javascript handles Wicket Ajax events by setting up AjaxCallListeners to hit a new Javascript event proxy.  This proxy will pass on events to the appropriate cell Javascript model, which we identify with the extra parameters on the ajax request and the cell's component markupId.

Also introduce a Javascript GradebookAbstractCell model to define shared functions between the cell models.

As Wicket now replaces the entire cell when updating, the new Ajax handlers now ensure the Javascript models are kept up to date with their corresponding DOM element as it changes and that those &lt;td&gt; elements are also setup to handle any client-side features e.g. keyboard events (involved a slight Javascript refactor to allow cell models to setup things for themselves).
