### PR TITLE
Editing notifications

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -547,10 +547,15 @@ public class GradebookNgBusinessService {
  	    }
      }
     
+     /**
+      * Push a an notification into the cache that someone is editing this gradebook.
+      * there could be multiple people editing this gradebook so we store a map of events keyed on the user performing the action
+      * 
+      * @param gradebookUid
+      */
      private void pushEditingNotification(String gradebookUid) {
-    	 //get the current event stack for this site
-    	 //There could be multiple people editing this gradebook so we store a map of events
-    	 //keyed on the user performing the action
+    	 
+    	 //TODO do we need to tie into the event system so other edits also affect this?
     	 
     	 User currentUser = this.getCurrentUser();
     	 
@@ -564,9 +569,16 @@ public class GradebookNgBusinessService {
     		 n = new GbEditingNotification(this.getCurrentUser(), gradebookUid);
     		 
     	 } else {
-    		 //if we already have a notification for the current user, update the timestamp
+    		 
+    		 //check if we have one for this user
     		 n = notifications.get(currentUser.getEid());
-    		 n.setLastUpdated(new Date());
+
+    		 //if not, create, otherwise update timestamp
+    		 if(n == null) {
+        		 n = new GbEditingNotification(this.getCurrentUser(), gradebookUid);
+    		 } else {
+    			 n.setLastUpdated(new Date());
+    		 }
     		 
     	 }
     	 
@@ -576,6 +588,24 @@ public class GradebookNgBusinessService {
     	 //update the map in the cache
     	 cache.put(gradebookUid, notifications);
     	 
+     }
+     
+     /**
+      * Get a list of editing notifications for this gradebook. Excludes any notifications for the current user
+      * 
+      * @param gradebookUid the gradebook that we are interested in
+      * @return
+      */
+     public Map<String,GbEditingNotification> getEditingNotifications(String gradebookUid) {
+		
+    	 String currentUserId = this.getCurrentUser().getEid();
+    	 
+    	 Map<String,GbEditingNotification> notifications = (Map<String,GbEditingNotification>) cache.get(gradebookUid);
+    	 if(notifications != null) {
+    		notifications.remove(currentUserId);
+    	 }
+    	 
+    	 return notifications;
      }
     
 }

--- a/tool/src/java/org/sakaiproject/gradebookng/business/model/GbEditingNotification.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/model/GbEditingNotification.java
@@ -30,6 +30,7 @@ public class GbEditingNotification implements Serializable {
 	/** 
 	 * The gradebook uid is here for redundancy. 
 	 * The data is already stored in the cache against the gradebook uid.
+	 * TODO I think we might remove this field
 	 */
 	@Getter @Setter
 	private String gradebookUid;

--- a/tool/src/java/org/sakaiproject/gradebookng/business/model/GbEditingNotification.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/model/GbEditingNotification.java
@@ -1,0 +1,44 @@
+package org.sakaiproject.gradebookng.business.model;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import org.sakaiproject.user.api.User;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The data packet that is persisted in the cache when someone is editing
+ * 
+ * @author Steve Swinsburg (steve.swinsburg@gmail.com)
+ *
+ */
+public class GbEditingNotification implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+	
+	@Getter
+	private String editorEid;
+	
+	@Getter
+	private String editorName;
+	
+	@Getter @Setter
+	private Date lastUpdated;
+	
+	/** 
+	 * The gradebook uid is here for redundancy. 
+	 * The data is already stored in the cache against the gradebook uid.
+	 */
+	@Getter @Setter
+	private String gradebookUid;
+	
+	public GbEditingNotification(User u, String gradebookUid){
+		this.editorEid = u.getEid();
+		this.editorEid = u.getDisplayName();
+		this.gradebookUid = gradebookUid;
+		this.lastUpdated = new Date();
+	}
+	
+}

--- a/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
@@ -25,6 +25,7 @@ import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.Permissions;
+import org.sakaiproject.gradebookng.business.model.GbEditingNotification;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
@@ -126,10 +127,39 @@ public class GradebookNgEntityProvider extends AbstractEntityProvider implements
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-				
-		
 		
 	}
+	
+	/**
+	 * Endpoint for getting the flag if another user is editing the gradebook 
+	 * This is designed to be polled on a regular basis so must be lightweight
+	 * @param view
+	 * @return
+	 */
+	@EntityCustomAction(action = "isotheruserediting", viewKey = EntityView.VIEW_LIST)
+	public Map<String, GbEditingNotification> isAnotherUserEditing(EntityView view) {
+		
+		// get siteId
+		String siteId = view.getPathSegment(2);
+		
+		// check siteId supplied
+		if (StringUtils.isBlank(siteId)) {
+			throw new IllegalArgumentException(
+					"Site ID must be set in order to access GBNG data.");
+		}
+		checkValidSite(siteId);
+
+		// check instructor
+		checkInstructor(siteId);
+		
+		// get notification list
+		// NOTE we assume the gradebook id and siteid are equivalent, which they are
+		// unless they have two gradebooks in a site? Is that even possible?
+		return this.businessService.getEditingNotifications(siteId);
+	}
+	
+	
+	
 	/**
 	 * Helper to check if the user is an instructor. Throws IllegalArgumentException if not.
 	 * We don't currently need the value that this produces so we don't return it.

--- a/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -9,7 +9,8 @@
 
 	<bean
 		id="org.sakaiproject.gradebookng.business.GradebookNgBusinessService"
-		class="org.sakaiproject.gradebookng.business.GradebookNgBusinessService">
+		class="org.sakaiproject.gradebookng.business.GradebookNgBusinessService"
+		init-method="init">
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 		<property name="userDirectoryService"
 			ref="org.sakaiproject.user.api.UserDirectoryService" />
@@ -18,8 +19,8 @@
 			ref="org_sakaiproject_service_gradebook_GradebookService" />
 		<property name="courseManagementService"
 			ref="org.sakaiproject.coursemanagement.api.CourseManagementService" />
-		<!-- <property name="xmlMarshaller" ref="org.sakaiproject.gradebookng.business.XmlMarshaller" 
-			/> -->
+		<property name="memoryService" ref="org.sakaiproject.memory.api.MemoryService" />
+			
 	</bean>
 
 	<bean


### PR DESCRIPTION
This adds the ability to track who is editing the gradebook as well as an entityprovider that the front end can use to get the data and display it on some sort of polling frequency.
Entries are stored in a cache which needs to be tuned via sakai.properties, with a TTL of about 10 seconds.
