### PR TITLE
Respecting categorized ordering and persisting this upon drag and drop when categories are enabled

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -585,14 +585,31 @@ public class GradebookNgBusinessService {
 
 
   /**
-   * Get the ordered categorized assignment ids
+   * Get the ordered categorized assignment ids for the current site
+   */
+  public Map<String, List<Long>> getCategorizedAssignmentOrder() {
+    try {
+      return getCategorizedAssignmentOrder(getCurrentSiteId());
+    } catch (JAXBException e) {
+      e.printStackTrace();
+    } catch(IdUnusedException e) {
+      e.printStackTrace();
+    } catch(PermissionException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+
+  /**
+   * Get the ordered categorized assignment ids for the siteId
    *
    * @param siteId	the siteId
    * @throws JAXBException
    * @throws IdUnusedException
    * @throws PermissionException
    */
-  public Map<String, List<Long>> getCategorizedAssignmentOrder(String siteId) {
+  private Map<String, List<Long>> getCategorizedAssignmentOrder(String siteId) throws JAXBException, IdUnusedException, PermissionException {
     Gradebook gradebook = (Gradebook)gradebookService.getGradebook(siteId);
 
     Site site = null;

--- a/tool/src/java/org/sakaiproject/gradebookng/business/dto/AssignmentOrder.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/dto/AssignmentOrder.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Class for storing the order of an assignment.
+ * Class for storing the categorized order of an assignment.
  * 
  * A list of these is persisted as XML into the site tool properties and used for sorting
  * 
@@ -26,20 +26,26 @@ public class AssignmentOrder {
 	@Getter
 	@Setter
 	@XmlElement
-	private long assignmentId;
+	private Long assignmentId;
 	
 	@Getter
 	@Setter
 	@XmlElement
-	private int order;	
-	
-	@SuppressWarnings("unused")
+	private int order;
+
+  @Getter
+  @Setter
+  @XmlElement
+  private String category;
+
+  @SuppressWarnings("unused")
 	private AssignmentOrder() {
 		//JAXB constructor
 	}
 	
-	public AssignmentOrder(long assignmentId, int order) {
-		this.assignmentId = assignmentId;
+	public AssignmentOrder(long assignmentId, String category, int order) {
+		this.assignmentId = new Long(assignmentId);
+    this.category = category;
 		this.order = order;
 	}
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
@@ -147,6 +147,38 @@ public class GradebookNgEntityProvider extends AbstractEntityProvider implements
 	
 	
 	
+	@EntityCustomAction(action = "categorized-assignment-order", viewKey = EntityView.VIEW_NEW)
+	public void updateCategorizedAssignmentOrder(EntityReference ref, Map<String, Object> params) {
+
+		// get params
+		String siteId = (String) params.get("siteId");
+		long assignmentId = NumberUtils.toLong((String) params.get("assignmentId"));
+		int order = NumberUtils.toInt((String) params.get("order"));
+
+		// check params supplied are valid 
+		if (StringUtils.isBlank(siteId) || assignmentId == 0 || order < 0) {
+			throw new IllegalArgumentException(
+			"Request data was missing / invalid");
+		}
+		checkValidSite(siteId);
+
+		// check instructor
+		checkInstructor(siteId);
+
+		//update the order
+		try {
+			this.businessService.updateCategorizedAssignmentOrder(siteId, assignmentId, order);
+		} catch (IdUnusedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (PermissionException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (JAXBException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
 	/**
 	 * Helper to check if the user is an instructor. Throws IllegalArgumentException if not.
 	 * We don't currently need the value that this produces so we don't return it.

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -110,6 +110,7 @@ public class GradebookPage extends BasePage {
         
         //get the grade matrix
         final List<StudentGradeInfo> grades = businessService.buildGradeMatrix(assignments);
+
 		Temp.time("buildGradeMatrix", stopwatch.getTime());
 		
 		//if the grade matrix is null, we dont have any data
@@ -119,6 +120,9 @@ public class GradebookPage extends BasePage {
 		}
 		
         
+
+        final Map<String, List<Long>> categorizedAssignmentOrder = businessService.getCategorizedAssignmentOrder();
+
         final ListDataProvider<StudentGradeInfo> studentGradeMatrix = new ListDataProvider<StudentGradeInfo>(grades);
         List<IColumn> cols = new ArrayList<IColumn>();
         
@@ -182,6 +186,10 @@ public class GradebookPage extends BasePage {
             	@Override
             	public Component getHeader(String componentId) {
             		AssignmentColumnHeaderPanel panel = new AssignmentColumnHeaderPanel(componentId, new Model<Assignment>(assignment));
+                String category = assignment.getCategoryName();
+                int order = categorizedAssignmentOrder.get(category).indexOf(assignment.getId());
+                panel.add(new AttributeModifier("data-category", category));
+                panel.add(new AttributeModifier("data-catagorized-order", order));
     				return panel;
             	}
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -189,7 +189,7 @@ public class GradebookPage extends BasePage {
                 String category = assignment.getCategoryName();
                 int order = categorizedAssignmentOrder.get(category).indexOf(assignment.getId());
                 panel.add(new AttributeModifier("data-category", category));
-                panel.add(new AttributeModifier("data-catagorized-order", order));
+                panel.add(new AttributeModifier("data-categorized-order", order));
     				return panel;
             	}
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -187,7 +187,10 @@ public class GradebookPage extends BasePage {
             	public Component getHeader(String componentId) {
             		AssignmentColumnHeaderPanel panel = new AssignmentColumnHeaderPanel(componentId, new Model<Assignment>(assignment));
                 String category = assignment.getCategoryName();
-                int order = categorizedAssignmentOrder.get(category).indexOf(assignment.getId());
+                int order = -1;
+                if (categorizedAssignmentOrder.containsKey(category)) {
+                  order = categorizedAssignmentOrder.get(category).indexOf(assignment.getId());
+                }
                 panel.add(new AttributeModifier("data-category", category));
                 panel.add(new AttributeModifier("data-categorized-order", order));
     				return panel;

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1322,7 +1322,7 @@ GradebookHeaderCell.prototype.hide = function() {
 
 
 GradebookHeaderCell.prototype.getCategorizedOrder = function() {
-  return this.$cell.find("[data-catagorized-order]").data("catagorized-order");
+  return this.$cell.find("[data-categorized-order]").data("categorized-order");
 }
 
 

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -334,7 +334,7 @@ GradebookSpreadsheet.prototype.setupFixedTableHeader = function(reset) {
       $.each($tr.find("td, th"), function(i, th) {
         var $th = $(th);
         var $clone = self._cloneCell($th);
-        model = $th.data("model");
+        var model = $th.data("model");
         if (model) {
           model.setFixedHeaderCell($clone);
         }
@@ -610,10 +610,10 @@ GradebookSpreadsheet.prototype.setupColumnDragAndDrop = function() {
 
     if (self.isGroupedByCategory()) {
       // determine the new position of the grade item in relation to grade items in this category
-      var order = $.inArray(model, self._CATEGORIES_MAP[model.getCategory()]);
+      var order = $.inArray(sourceModel, self._CATEGORIES_MAP[sourceModel.getCategory()]);
       GradebookAPI.updateCategorizedAssignmentOrder(self.$table.data("siteid"),
-                                                    model.columnKey,
-                                                    model.getCategory(),
+                                                    sourceModel.columnKey,
+                                                    sourceModel.getCategory(),
                                                     order);
     } else {
       GradebookAPI.updateAssignmentOrder(self.$table.data("siteid"),
@@ -755,7 +755,7 @@ GradebookSpreadsheet.prototype.disableGroupByCategory = function() {
 
   // reorder based on self.originalOrder
   for(i=0,newColIndex=3; i < self._COLUMN_ORDER.length; i++,newColIndex++) {
-    model = self._COLUMN_ORDER[i];
+    var model = self._COLUMN_ORDER[i];
     model.moveColumnTo(newColIndex);
   }
 


### PR DESCRIPTION
I've reintroduced the order XML but slightly tweaked it to take into account the assignment's category.  Now when an the page is loaded, we grab this XML and poke the corresponding order onto the header cell so the Javascript can use it when reordering the cells upon enabling categories.

When a drag and drop is performed when categories are enabled, we persist this order via a new endpoint that updates the XML values and stores it.

There's a bit of Java wrangling in this one, so @steveswinsburg it could use a good review!  Thanks :cake: 
