### PR TITLE
Fix javascript error when trying to show/hide an external grade item

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -57,6 +57,7 @@ public class GradeItemCellPanel extends Panel {
 		//if assignment is external, normal label
 		if(BooleanUtils.isTrue(isExternal)){
 			add(new Label("grade", Model.of(formattedGrade)));
+			getParent().add(new AttributeModifier("class", "gb-external-item-cell"));
 		} else {
 			AjaxEditableLabel<String> gradeCell = new AjaxEditableLabel<String>("grade", Model.of(formattedGrade)) {
 				

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -79,6 +79,10 @@ GradebookSpreadsheet.prototype.setupGradeItemCellModels = function() {
         cellModel = new GradebookEditableCell($cell, tmpHeaderByIndex[cellIndex], self);
 
         self._GRADE_CELLS[studentUuid][cellModel.header.columnKey] = cellModel;
+      } else if (self.isCellForExternalItem($cell)) {
+        cellModel = new GradebookBasicCell($cell, tmpHeaderByIndex[cellIndex], self);
+
+        self._GRADE_CELLS[studentUuid][cellModel.header.columnKey] = cellModel;
       } else {
         cellModel = new GradebookBasicCell($cell, tmpHeaderByIndex[cellIndex], self);
       }
@@ -252,6 +256,11 @@ GradebookSpreadsheet.prototype.ensureCellIsVisible = function($cell) {
 
 GradebookSpreadsheet.prototype.isCellEditable = function($cell) {
   return $cell.hasClass("gb-grade-item-cell");
+};
+
+
+GradebookSpreadsheet.prototype.isCellForExternalItem = function($cell) {
+  return $cell.hasClass("gb-external-item-cell");
 };
 
 
@@ -854,6 +863,12 @@ var GradebookAbstractCell = {
                  self.gradebookSpreadsheet.ensureCellIsVisible($(event.target));
                  self.gradebookSpreadsheet.highlightRow(self.getRow());
                });
+  },
+  show: function() {
+    this.$cell.show();
+  },
+  hide: function() {
+    this.$cell.hide();
   }
 };
 
@@ -961,16 +976,6 @@ GradebookEditableCell.prototype.enterEditMode = function(withValue) {
 
   // Trigger click on the Wicket node so we enter the edit mode
   self.$cell.find("span[id^='label']").trigger("click");
-};
-
-
-GradebookEditableCell.prototype.show = function() {
-  this.$cell.show();
-};
-
-
-GradebookEditableCell.prototype.hide = function() {
-  this.$cell.hide();
 };
 
 

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -131,7 +131,8 @@
 #gradebookGrades tbody td.gb-cell {
   height: 2.6em;
 }
-#gradebookGrades .gb-grade-item-cell {
+#gradebookGrades .gb-grade-item-cell,
+#gradebookGrades .gb-external-item-cell {
   text-align: center;
   white-space: nowrap;
 }


### PR DESCRIPTION
I've had to refactor a few little things so that external item cells are not treated like editable cells but place nice with the standard keyboard and toggle behaviours.

Also poke a new CSS class on external item cells `gb-external-item-cell` so we can style them accordingly.
