### PR TITLE
Add a javascript method to the spreadsheet model to offer a quick wayto hide a column and ensure the toolbar remains in sync

### DIFF
--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -860,6 +860,12 @@ GradebookSpreadsheet.prototype.setupRowSelector = function() {
 };
 
 
+GradebookSpreadsheet.prototype.hideGradeItemAndSyncToolbar = function(assignmentId) {
+  var $input = this.toolbarModel.$gradeItemsFilterPanel.find(".gradebook-item-filter :input").filter("[value='"+assignmentId+"']");
+  $input.trigger("click");
+};
+
+
 /*************************************************************************************
  * AbstractCell - behaviour inherited by all cells
  */


### PR DESCRIPTION
Hi @steveswinsburg,

As discussed, I've added a javascript call that will allow you to quickly hide a column and also ensure the toolbar remains in sync.  I've added this method to the spreadsheet model so you can access it like:

```
 // param: assignmentId (string or int will be fine)
 sakai.gradebookng.spreadsheet.hideGradeItemAndSyncToolbar("17");
```
