### PR TITLE
Don't start drag (or focus header cell) if the dropdown menu is clicked

### DIFF
--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -655,6 +655,7 @@ GradebookSpreadsheet.prototype.setupColumnDragAndDrop = function() {
     scrollSensitivity: 100,
     opacity: 0.9,
     zIndex: 1000,
+    cancel: '.btn-group, .btn-group *', // don't start drag if the dropdown menu is clicked
     start: function(event, ui) {
       $(ui.helper.context).addClass("gb-grade-item-drag-source");
       // enable all droppable


### PR DESCRIPTION
In response to #76.

The reason that focus is allowed on header cells is because they are currently included in the keyboard navigation.  So when clicking the cell (or anything inside it) it attempts to focus that cell so keyboard navigation may continue from that point.  Happy to change this, but I have a feeling that it was desirable to have the header included in the keyboard nav?

I think I fixed the issue whereby clicking the dropdown would be caught by the cell focus.  This was due to the draggable handler as it catches on mousedown.  The draggable setup will now "cancel drag" if the click event is on the dropdown button (or any element within that dropdown).
