### PR TITLE
Fix NPE when building categorzied and ordered assignments

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -657,13 +657,16 @@ public class GradebookNgBusinessService {
         Map<String, List<Long>> result = new HashMap<String, List<Long>>();
         List<AssignmentOrder> assignmentOrders = xmlList.getItems();
 
+        // Sort the assignments by their category and then order
         Collections.sort(assignmentOrders, new AssignmentOrderComparator());
 
         for (AssignmentOrder ao : assignmentOrders) {
+          // add the category if the XML doesn't have it already
           if (!result.containsKey(ao.getCategory())) {
             result.put(ao.getCategory(), new ArrayList<Long>());
           }
-          result.get(ao.getCategory()).add(ao.getOrder(), ao.getAssignmentId());
+
+          result.get(ao.getCategory()).add(ao.getAssignmentId());
         }
 
         return result;
@@ -965,7 +968,20 @@ public class GradebookNgBusinessService {
     class AssignmentOrderComparator implements Comparator<AssignmentOrder> {
       @Override
       public int compare(AssignmentOrder ao1, AssignmentOrder ao2) {
-        return ((Integer) ao1.getOrder()).compareTo(ao2.getOrder());
+        // Deal with uncategorized assignments (nulls!)
+        if (ao1.getCategory() == null && ao2.getCategory() == null) {
+          return ((Integer) ao1.getOrder()).compareTo(ao2.getOrder());
+        } else if (ao1.getCategory() == null) {
+          return 1;
+        } else if (ao2.getCategory() == null) {
+          return -1;
+        }
+        // Deal with friendly categorized assignments
+        if (ao1.getCategory().equals(ao2.getCategory())) {
+          return ((Integer) ao1.getOrder()).compareTo(ao2.getOrder());
+        } else {
+          return ((String) ao1.getCategory()).compareTo(ao2.getCategory());
+        }
       }
     }
 }


### PR DESCRIPTION
Hi @steveswinsburg, sorry only just got to this.

I'm building a hash of the categorized and ordered assignments for the templates and javascript to use.  I think the error happens when there are uncategorized assignments.  Plus there was also an issue when the sequence of order wasn't incremental (an assignment was moved to another category and so the zeroth item was moved to a new array). 

I've modified the comparator to do the work and order them best as can be before building the required hash. 

If issues continue I'll refactor to use Java 8's Optional - NPEs suck.
