### PR TITLE
Update import/export first step page wording 

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -89,17 +89,12 @@ column.header.studentsummary.grade = Grade
 column.header.studentsummary.weight = Weight
 column.header.studentsummary.comments = Comments
 
-importExport.import.heading = Import Grades
-importExport.import.description = If you would prefer to structure your Gradebook/enter grades in the spreadsheet application of your choice, you may download either a <strong>Blank Template</strong> or <strong>Full Gradebook</strong> \ 
-                                  with all currently created items/scores in place, then import the edited spreadsheet into the Gradebook.
-
-importExport.template.description = Note: If structuring your Gradebook using the <strong>Blank Template</strong> option, follow the formatting conventions used in the placeholder columns to ensure this information can be \
-                                 properly imported.
-importExport.template.button.blankTemplate = Blank Template
-importExport.template.button.fullGradebook = Full Gradebook
-
-importExport.upload.description = When ready to import items/grades, select Browse to upload your updated spreadsheet, then select Continue. On the following screens, you may choose the content \
-                                 that you would like to import and will be guided through the creation of any new items.
+importExport.export.heading = Export
+importExport.export.description = Export your Gradebook as a .csv file in order to enter grades/structure your Gradebook in the spreadsheet application of your choice.
+importExport.import.heading = Import
+importExport.import.description = Selectively import new grades/Gradebook items into the Gradebook by uploading an edited .csv version of your Gradebook below.
+importExport.template.description = Note: The formatting of the uploaded spreadsheet must match the conventions in the downloadable Gradebook file above.
+importExport.template.button.fullGradebook = Download Gradebook
 
 importExport.selection.heading = Gradebook Item Import Selection
 importExport.selection.description = The system has analyzed the contents of your file upload and has identified new/updated \

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.html
@@ -1,23 +1,17 @@
 <wicket:panel xmlns:wicket="http://wicket.apache.org">
 
-    <h2><wicket:message key="importExport.import.heading" /></h2>
+    <section class="gb-import-export-section">
+        <h2><wicket:message key="importExport.export.heading" /></h2>
+          
+        <p><wicket:message key="importExport.export.description" /></p>
+        <p><input type="button" wicket:id="downloadFullGradebook" wicket:message="value:importExport.template.button.fullGradebook"/></p>
+    </section>
 
-    <p><wicket:message key="importExport.import.description" /></p>
+    <section class="gb-import-export-section">
+        <h2><wicket:message key="importExport.import.heading" /></h2>
 
-    <div>
+        <p><wicket:message key="importExport.import.description" /></p>
         <p><wicket:message key="importExport.template.description" /></p>
-        <ul class="exportToolbar">
-          <li>
-            <input type="button" wicket:id="downloadBlankTemplate" wicket:message="value:importExport.template.button.blankTemplate"/>
-          </li>
-          <li>
-            <input type="button" wicket:id="downloadFullGradebook" wicket:message="value:importExport.template.button.fullGradebook"/>
-          </li>
-        </ul>
-    </div>
-
-    <div>
-        <p><wicket:message key="importExport.upload.description" /></p>
 
         <form wicket:id="form">
             <fieldset>
@@ -30,6 +24,6 @@
             </div>
         </form>
 
-    </div>
+    </section>
 
 </wicket:panel>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
@@ -65,14 +65,6 @@ public class GradeImportUploadStep extends Panel {
         //get the grade matrix
         grades = businessService.buildGradeMatrix(assignments);
 
-        add(new DownloadLink("downloadBlankTemplate", new LoadableDetachableModel<File>() {
-
-            @Override
-            protected File load() {
-                return buildFile(false);
-            }
-        }).setCacheDuration(Duration.NONE).setDeleteAfterDownload(true));
-
         add(new DownloadLink("downloadFullGradebook", new LoadableDetachableModel<File>() {
 
             @Override

--- a/tool/src/webapp/styles/gradebook-importexport.css
+++ b/tool/src/webapp/styles/gradebook-importexport.css
@@ -29,3 +29,11 @@
   font-style: italic;
   text-indent: 15px;
 }
+
+#gradebookImportExport .gb-import-export-section h2 {
+  margin: 1.5em 0 0;
+}
+#gradebookImportExport .gb-import-export-section p,
+#gradebookImportExport .gb-import-export-section form {
+  margin: 1em 0 0;
+}


### PR DESCRIPTION
From Kyle's email to update wording on the first import/export page...

I've also added some styles/margins to the content within the tool as the morpheus reset is currently removing all margins from p, h2, etc.

I removed the Blank Template link from the panel, but left the code in there to generate it.. just in case.
