### PR TITLE
Fix keyboard return wiping cell value when entering edit mode

### DIFF
--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1123,7 +1123,7 @@ GradebookEditableCell.prototype.setupWicketInputField = function(withValue) {
 
   var $input = self.$cell.find(":input:first");
 
-  if (withValue != null) {
+  if (withValue != null && withValue != "") {
     // set the value after the focus to ensure the cursor is
     // positioned after the new value
     $input.focus();


### PR DESCRIPTION
Fix hitting return on a cell with a value causing that cell to become empty.  The cell should retain the existing value when return is used to invoke the edit input.
