### PR TITLE
Mobile friendly cells and notifications

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -151,5 +151,11 @@ grade.option.viewlog = Grade Log
 grade.log.entry = {0} - Score set to <b>{1}</b> by {2}
 grade.log.none = No grades have been entered for this cell.
 
+grade.notifications.hascomment = Gradebook item has comments
+grade.notifications.haserror = An error occurred updating the gradebook item
+grade.notifications.overlimit = Gradebook item score is over point value
+grade.notifications.concurrentedit = A concurrent edit has been detected. Please refresh the page for the most up to date scores.
+grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool 
+
 comment.option.add = Add Comment
 comment.option.edit = Edit Comment

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd" >
+
+<body>
+<wicket:panel>
+
+    <ul class="gb-popover-notifications">
+        <li wicket:id="saveErrorNotification" class="gb-popover-notification-error text-danger"><span wicket:id="message"></span></li>
+        <li wicket:id="concurrentEditNotification" class="gb-popover-notification-concurrentedit text-danger"><span wicket:id="message"></span></li>
+        <li wicket:id="isOverLimitNotification" class="gb-popover-notification-overlimit text-warning"><span wicket:id="message"></span></li>
+        <li wicket:id="hasCommentNotification" class="gb-popover-notification-has-comment text-info"><span wicket:id="message"></span></li>
+        <li wicket:id="isExternalNotification" class="gb-popover-notification-is-external text-info"><span wicket:id="message"></span></li>
+    </ul>
+
+</wicket:panel>
+</body>
+</html>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
@@ -1,0 +1,44 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.ResourceModel;
+
+public class GradeItemCellPopoverPanel extends Panel {
+
+	public GradeItemCellPopoverPanel(String id, IModel<Map<String,Object>> model, List<GradeItemCellPanel.GradeCellNotification> notifications) {
+		super(id, model);
+
+		WebMarkupContainer saveErrorNotification = new WebMarkupContainer("saveErrorNotification");
+		saveErrorNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.ERROR));
+		saveErrorNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.ERROR.getMessage())));
+		add(saveErrorNotification);
+
+		WebMarkupContainer hasCommentNotification = new WebMarkupContainer("hasCommentNotification");
+		hasCommentNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.HAS_COMMENT));
+		hasCommentNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.HAS_COMMENT.getMessage())));
+		add(hasCommentNotification);
+
+		WebMarkupContainer isOverLimitNotification = new WebMarkupContainer("isOverLimitNotification");
+		isOverLimitNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.OVER_LIMIT));
+		isOverLimitNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.OVER_LIMIT.getMessage())));
+		add(isOverLimitNotification);
+
+		WebMarkupContainer concurrentEditNotification = new WebMarkupContainer("concurrentEditNotification");
+		concurrentEditNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.CONCURRENT_EDIT));
+		concurrentEditNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.CONCURRENT_EDIT.getMessage())));
+		add(concurrentEditNotification);
+
+		WebMarkupContainer isExternalNotification = new WebMarkupContainer("isExternalNotification");
+		isExternalNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.IS_EXTERNAL));
+		isExternalNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.IS_EXTERNAL.getMessage())));
+		add(isExternalNotification);
+	}
+
+}

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -510,6 +510,33 @@
 #gradebookGrades .gb-student-filter-clear:hover {
   text-decoration: none;
 }
+/* Popover Notifications */
+.gb-popover-notifications {
+  min-width: 200px;
+  max-width: 300px;
+}
+.gb-popover-notifications li {
+  margin-bottom: 10px;
+}
+.gb-popover-notifications li:before {
+  margin-right: 5px;
+}
+.gb-popover-notifications .gb-popover-notification-error:before {
+  font-family: "gradebook-icons";
+  content: "\f06a";
+}
+.gb-popover-notifications .gb-popover-notification-overlimit:before {
+  font-family: "gradebook-icons";
+  content: "\f071";
+}
+.gb-popover-notifications .gb-popover-notification-has-comment:before {
+  font-family: "gradebook-icons";
+  content: '\f075';
+}
+.gb-popover-notifications .gb-popover-notification-concurrentedit:before {
+  font-family: "gradebook-icons";
+  content: '\f040';
+}
 /* Wicket Overrides */
 div.wicket-modal div.w_content_3 {
   border: none; /** don't want border wrapping content inside the modal **/


### PR DESCRIPTION
Introduce a bootstrap popover to display any cell-context messages (if any).

To assist mobile users, the cell has to be focused before edit can be entered. This means that any notifications can be viewed on the focus/first click or touch.. and a subsequent touch (or long touch) will enter the cell's edit mode.
