### PR TITLE
Fix drag handle being cloned into the fixed header

### DIFF
--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -645,7 +645,11 @@ GradebookSpreadsheet.prototype.setupColumnDragAndDrop = function() {
     hoverClass: "gb-grade-item-drag-hover",
     tolerance: "pointer",
     drop: function(event, ui) {
-      applyAndPersistOrder(ui.draggable, $(event.target));
+      // let the drop fully complete (DOM handle is removed, droppable updated)
+      // before updating any state
+      setTimeout(function() {
+        applyAndPersistOrder(ui.draggable, $(event.target));
+      });
     }
   });
 


### PR DESCRIPTION
Upon successfully completing a drag and drop the fixed header is updated to reflect the new order.  Because the drop hadn't fully completed updating the DOM the drag handle was included in the clone and shows up when the page is scrolled.  

This patch simply ensure this drag and drop Javascript process is complete before saving and updating the state of the table headers.
