### PR TITLE
Accessibility round one

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -39,7 +39,8 @@ column.header.section = Section
 column.header.students = Students
 column.header.coursegrade = Course Grade
 
-placeholder.students = Filter students
+filter.students = Filter students
+filter.groups = Filter by group/section
 
 button.addgradeitem = Add Gradebook Item
 button.savechanges = Save Changes

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -31,6 +31,7 @@
       <div id="gradebookGradesToolbar">
         <ul class="gb-toolbar-left">
           <li>
+            <label for="filterByGroup" style="display:none" aria-hidden="true"><wicket:message key="filter.groups" /></label>
             <select id="filterByGroup" wicket:id="groupFilter">
               <option value="1">Section 1</option>
               <option value="2">Section 2</option>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -16,7 +16,7 @@
 <wicket:extend>
   <form wicket:id="form">
     <p>
-      <button wicket:id="addGradeItem" class="gb-add-gradebook-item-button">
+      <button wicket:id="addGradeItem" class="gb-add-gradebook-item-button" aria-haspopup="true">
       	 <wicket:message key="button.addgradeitem" />
       </button>
     </p>
@@ -38,16 +38,16 @@
           </li>
         </ul>
         <ul class="gb-toolbar-right">
-          <li><span wicket:id="gradeItemSummary" class="gradebook-item-summary">Viewing <span class="counts"><strong class="visible">8</strong> out of <strong class="total">8</strong></span> Grade Items</span></li>
+          <li><span wicket:id="gradeItemSummary" class="gradebook-item-summary" role="status" aria-live="polite">Viewing <span class="counts"><strong class="visible">8</strong> out of <strong class="total">8</strong></span> Grade Items</span></li>
           <li>
-            <button id="toggleGradeItemsToolbarItem">Show/Hide Items</button>
+            <button id="toggleGradeItemsToolbarItem" aria-popup="true" aria-controls="gradeItemsTogglePanel">Show/Hide Items</button>
           </li>
           <li>
-            <button wicket:id="toggleCategoriesToolbarItem" id="toggleCategoriesToolbarItem">Group By Category</button>
+            <button wicket:id="toggleCategoriesToolbarItem" id="toggleCategoriesToolbarItem" aria-controls="gradebookGradesTable">Group By Category</button>
           </li>
         </ul>
       </div>
-      <table wicket:id="table" id="gradebookGradesTable" class="table-striped table-bordered table-hover"></table>
+      <table wicket:id="table" id="gradebookGradesTable" class="table-striped table-bordered table-hover" role="grid"></table>
     </div>
   </form>
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -253,6 +253,7 @@ public class GradebookPage extends BasePage {
         table.addBottomToolbar(new NavigationToolbar(table));
         table.addTopToolbar(new HeadersToolbar(table, null));
         table.add(new AttributeModifier("data-siteid", this.businessService.getCurrentSiteId()));
+        table.add(new AttributeModifier("role", "grid"));
         form.add(table);
 
         // Populate the toolbar 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -253,7 +253,6 @@ public class GradebookPage extends BasePage {
         table.addBottomToolbar(new NavigationToolbar(table));
         table.addTopToolbar(new HeadersToolbar(table, null));
         table.add(new AttributeModifier("data-siteid", this.businessService.getCurrentSiteId()));
-        table.add(new AttributeModifier("role", "grid"));
         form.add(table);
 
         // Populate the toolbar 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.html
@@ -27,16 +27,16 @@
 
 	<!-- dropdown -->
 	<div class="btn-group">
-	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-label="Show dropdown menu">
 	    	<span class="caret"></span>
 	    </a>
-	    <ul class="dropdown-menu dropdown-menu-right">
-	   		<li><a wicket:id="editAssignmentDetails" href="#"><wicket:message key="assignment.option.edit" /></a></li>
-	   		<li><a wicket:id="viewAssignmentGradeStatistics" href="#"><wicket:message key="assignment.option.viewgradestatistics" /></a></li>
-			<li><a wicket:id="moveAssignmentLeft" href="#" class="move-assignment-left"><wicket:message key="assignment.option.moveleft" /></a></li>
-			<li><a wicket:id="moveAssignmentRight" href="#" class="move-assignment-right"><wicket:message key="assignment.option.moveright" /></a></li>
-			<li><a wicket:id="hideAssignment" href="#"><wicket:message key="assignment.option.hide" /></a></li>
-	    	<li><a wicket:id="setUngraded" href="#"><wicket:message key="assignment.option.setungraded" /></a></li>
+	    <ul class="dropdown-menu dropdown-menu-right" role="menu">
+	   		<li><a wicket:id="editAssignmentDetails" href="#" role="menuitem"><wicket:message key="assignment.option.edit" /></a></li>
+	   		<li><a wicket:id="viewAssignmentGradeStatistics" href="#" role="menuitem"><wicket:message key="assignment.option.viewgradestatistics" /></a></li>
+			<li><a wicket:id="moveAssignmentLeft" href="#" class="move-assignment-left" role="menuitem"><wicket:message key="assignment.option.moveleft" /></a></li>
+			<li><a wicket:id="moveAssignmentRight" href="#" class="move-assignment-right" role="menuitem"><wicket:message key="assignment.option.moveright" /></a></li>
+			<li><a wicket:id="hideAssignment" href="#" role="menuitem"><wicket:message key="assignment.option.hide" /></a></li>
+	    	<li><a wicket:id="setUngraded" href="#" role="menuitem" aria-haspopup="true"><wicket:message key="assignment.option.setungraded" /></a></li>
 	    </ul>
     </div>
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
@@ -12,8 +12,8 @@
 	    	<span class="caret"></span>
 	    </a>
 	    <ul class="dropdown-menu dropdown-menu-right" role="menu">
-	   		<li><a wicket:id="viewGradeLog" href="#" role="menu-item" aria-haspopup="true"><wicket:message key="grade.option.viewlog" /></a></li>
-			<li><a wicket:id="editGradeComment" href="#" role="menu-item" aria-haspopup="true"><span wicket:id="editGradeCommentLabel">View / Edit Comments</span></a></li>
+	   		<li><a wicket:id="viewGradeLog" href="#" role="menuitem" aria-haspopup="true"><wicket:message key="grade.option.viewlog" /></a></li>
+			<li><a wicket:id="editGradeComment" href="#" role="menuitem" aria-haspopup="true"><span wicket:id="editGradeCommentLabel">View / Edit Comments</span></a></li>
 	    </ul>
     </div>
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
@@ -8,12 +8,12 @@
 	
 	<!--  from wicket bootstrap, needs to be sorted out -->
 	<div class="btn-group">
-	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-label="Show dropdown menu">
 	    	<span class="caret"></span>
 	    </a>
-	    <ul class="dropdown-menu dropdown-menu-right">
-	   		<li><a wicket:id="viewGradeLog" href="#"><wicket:message key="grade.option.viewlog" /></a></li>
-			<li><a wicket:id="editGradeComment" href="#"><span wicket:id="editGradeCommentLabel">View / Edit Comments</span></a></li>
+	    <ul class="dropdown-menu dropdown-menu-right" role="menu">
+	   		<li><a wicket:id="viewGradeLog" href="#" role="menu-item" aria-haspopup="true"><wicket:message key="grade.option.viewlog" /></a></li>
+			<li><a wicket:id="editGradeComment" href="#" role="menu-item" aria-haspopup="true"><span wicket:id="editGradeCommentLabel">View / Edit Comments</span></a></li>
 	    </ul>
     </div>
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -277,11 +277,11 @@ public class GradeItemCellPanel extends Panel {
 			gradeCell.setOutputMarkupId(true);
 						
 			add(gradeCell);
-
-			getParent().add(new AttributeModifier("role", "gridcell"));
-			getParent().add(new AttributeModifier("aria-readonly", Boolean.toString(isExternal)));
 		}
-									
+
+		getParent().add(new AttributeModifier("role", "gridcell"));
+		getParent().add(new AttributeModifier("aria-readonly", Boolean.toString(isExternal)));
+
 		//menu
 		
 		//grade log

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -277,6 +277,9 @@ public class GradeItemCellPanel extends Panel {
 			gradeCell.setOutputMarkupId(true);
 						
 			add(gradeCell);
+
+			getParent().add(new AttributeModifier("role", "gridcell"));
+			getParent().add(new AttributeModifier("aria-readonly", Boolean.toString(isExternal)));
 		}
 									
 		//menu

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.html
@@ -4,7 +4,7 @@
 <body>
 <wicket:panel>
 	
-	<a href="#" wicket:id="link" class="gb-student-label">
+	<a href="#" wicket:id="link" class="gb-student-label" aria-haspopup="true">
 		<span wicket:id="name">John Smith</span> (<span wicket:id="eid">(js1234)</span>)
 	</a>
 		

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.java
@@ -2,6 +2,7 @@ package org.sakaiproject.gradebookng.tool.panels;
 
 import java.util.Map;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
@@ -74,7 +75,8 @@ public class StudentNameCellPanel extends Panel {
 		
 		add(link);
 		
-		
+		getParent().add(new AttributeModifier("scope", "row"));
+		getParent().add(new AttributeModifier("role", "rowheader"));
 
 	}
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
@@ -7,13 +7,14 @@
 	<div wicket:id="title" class="gb-title"></div>
 	
 	<div class="gb-student-filter">
-	  <input type="text" id="studentFilterInput" wicket:message="placeholder:placeholder.students" aria-controls="gradebookGradesTable" />
+	  <label for="studentFilterInput" style="display:none" aria-hidden="true"><wicket:message key="filter.groups" /></label>
+	  <input type="text" id="studentFilterInput" wicket:message="placeholder:filter.students" aria-controls="gradebookGradesTable" />
 	  <a id="studentFilterClear" class="gb-student-filter-clear" href="javascript:void(0);" aria-controls="studentFilterInput" aria-label="Clear student filter"></a>
 	</div>
 	
 	<!--  this comes from the wicket bootstrap module, needs to be sorted out. -->
 	<div class="btn-group">
-	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true">
+	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-label="Show dropdown menu">
 	    	<span class="caret"></span>
 	    </a>
 	    <ul class="dropdown-menu dropdown-menu-right" role="menu">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.html
@@ -7,18 +7,18 @@
 	<div wicket:id="title" class="gb-title"></div>
 	
 	<div class="gb-student-filter">
-	  <input type="text" id="studentFilterInput" wicket:message="placeholder:placeholder.students" />
-	  <a id="studentFilterClear" class="gb-student-filter-clear" href="javascript:void(0);"></a>
+	  <input type="text" id="studentFilterInput" wicket:message="placeholder:placeholder.students" aria-controls="gradebookGradesTable" />
+	  <a id="studentFilterClear" class="gb-student-filter-clear" href="javascript:void(0);" aria-controls="studentFilterInput" aria-label="Clear student filter"></a>
 	</div>
 	
 	<!--  this comes from the wicket bootstrap module, needs to be sorted out. -->
 	<div class="btn-group">
-	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+	    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true">
 	    	<span class="caret"></span>
 	    </a>
-	    <ul class="dropdown-menu dropdown-menu-right">
+	    <ul class="dropdown-menu dropdown-menu-right" role="menu">
 	   		<!-- <li><a href="#">Sort by Last Name</a></li> -->
-	   		<li><a href="#">Sort by First Name</a></li>
+	   		<li><a href="#" role="menuitem" aria-controls="gradebookGradesTable">Sort by First Name</a></li>
 	    </ul>
     </div>
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.html
@@ -4,41 +4,41 @@
 <body>
 <wicket:panel>
 
-<div id="gradeItemsToolbarItemPanel">
-  <a href="javascript:void(0)" id="hideAllGradeItems"><span wicket:message="value:label.toolbar.gradeitemhideall">Hide All</span></a>
-  <a href="javascript:void(0)" id="showAllGradeItems"><span wicket:message="value:label.toolbar.gradeitemshowall">Show All</span></a>
+<div id="gradeItemsToolbarItemPanel" role="menu">
+  <a href="javascript:void(0)" id="hideAllGradeItems" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemhideall">Hide All</span></a>
+  <a href="javascript:void(0)" id="showAllGradeItems" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowall">Show All</span></a>
   <div wicket:id="categoriesList" class="gradebook-item-filter-group">
     <div class="gradebook-item-category-filter">
-      <label tabindex="0">
+      <label tabindex="0" role="menuitem">
         <span wicket:id="category"></span>
         <span class="gradebook-item-category-filter-signal"></span>
         <input wicket:id="categoryCheckbox" type="checkbox">
       </label>
       <div class="btn-group">
-        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-popup="true" aria-label="Show dropdown menu">
           <span class="caret"></span>
         </a>
-        <ul class="dropdown-menu dropdown-menu-right">
-          <li><a class="gb-show-only-this-category" href="#"><span wicket:message="value:label.toolbar.gradeitemshowonlythiscategory">Show only this category</span></a></li>
-          <li><a class="gb-toggle-this-category gb-show-this-category" href="#"><span wicket:message="value:label.toolbar.gradeitemshowthiscategory">Show this category</span></a></li>
-          <li><a class="gb-toggle-this-category gb-hide-this-category" href="#"><span wicket:message="value:label.toolbar.gradeitemhidethiscategory">Hide this category</span></a></li>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li><a class="gb-show-only-this-category" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowonlythiscategory">Show only this category</span></a></li>
+          <li><a class="gb-toggle-this-category gb-show-this-category" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowthiscategory">Show this category</span></a></li>
+          <li><a class="gb-toggle-this-category gb-hide-this-category" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemhidethiscategory">Hide this category</span></a></li>
         </ul>
       </div>
     </div>
     <div wicket:id="assignmentsForCategory" class="gradebook-item-filter">
-      <label tabindex="0">
+      <label tabindex="0" role="menuitem">
         <span wicket:id="assignmentTitle"></span>
         <span class="gradebook-item-category-filter-signal"></span>
         <input wicket:id="assignmentCheckbox" type="checkbox">
       </label>
       <div class="btn-group">
-        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-popup="true" aria-label="Open dropdown menu">
           <span class="caret"></span>
         </a>
-        <ul class="dropdown-menu dropdown-menu-right">
-          <li><a class="gb-show-only-this-item" href="#"><span wicket:message="value:label.toolbar.gradeitemshowonlythisitem">Show only this item</span></a></li>
-          <li><a class="gb-toggle-this-item gb-show-this-item" href="#"><span wicket:message="value:label.toolbar.gradeitemshowthisitem">Show this item</span></a></li>
-          <li><a class="gb-toggle-this-item gb-hide-this-item" href="#"><span wicket:message="value:label.toolbar.gradeitemhidethisitem">Hide this item</span></a></li>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li><a class="gb-show-only-this-item" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowonlythisitem">Show only this item</span></a></li>
+          <li><a class="gb-toggle-this-item gb-show-this-item" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowthisitem">Show this item</span></a></li>
+          <li><a class="gb-toggle-this-item gb-hide-this-item" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemhidethisitem">Hide this item</span></a></li>
         </ul>
       </div>
     </div>

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -332,6 +332,7 @@ GradebookSpreadsheet.prototype.setupFixedTableHeader = function(reset) {
   var $fixedHeader = $("<table>").
                         attr("class", self.$table.attr("class")).
                         addClass("gb-fixed-header-table").
+                        attr("role", "presentation").
                         hide();
 
   $head.find("tr").each(function() {
@@ -401,8 +402,15 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
 
   // all columns before the grade item columns should be fixed
 
-  self.$fixedColumnsHeader = $("<table>").attr("class", self.$table.attr("class")).addClass("gb-fixed-column-headers-table").hide();
-  self.$fixedColumns = $("<table>").attr("class", self.$table.attr("class")).addClass("gb-fixed-columns-table").hide();
+  self.$fixedColumnsHeader = $("<table>").attr("class", self.$table.attr("class")).
+                                          addClass("gb-fixed-column-headers-table").
+                                          attr("role", "presentation").
+                                          hide();
+
+  self.$fixedColumns = $("<table>").attr("class", self.$table.attr("class")).
+                                    addClass("gb-fixed-columns-table").
+                                    attr("role", "presentation").
+                                    hide();
 
   var $headers = self.$table.find("thead tr > *:not(.gb-grade-item-column-cell)");
   var $thead = $("<thead>");

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1665,9 +1665,11 @@ GradebookToolbar.prototype.setupToggleGradeItems = function() {
 
     if ($(this).hasClass("on")) {
       repositionPanel();
-      self.$gradeItemsFilterPanel.show();
+      $(this).attr("aria-expanded", "true");
+      self.$gradeItemsFilterPanel.show().attr("aria-hidden", "false");
     } else {
-      self.$gradeItemsFilterPanel.hide();
+      $(this).attr("aria-expanded", "false");
+      self.$gradeItemsFilterPanel.hide().attr("aria-hidden", "true");
     }
 
     return false;

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1133,6 +1133,7 @@ GradebookEditableCell.prototype.setupKeyboardNavigation = function($input) {
     // ESC 27
     } else if (event.keyCode == 27) {
       self.$cell.focus();
+      self._focusAfterSaveComplete = true;
 
     // arrow keys
     } else if (event.keyCode >= 37 && event.keyCode <= 40) {
@@ -1239,13 +1240,18 @@ GradebookEditableCell.prototype.handleSaveComplete = function(cellId) {
   this.setupCell($("#"+cellId));
   this.setupClick();
   this.setupWicketLabelField();
-  
+
   //bind a timeout to the successful save. An easing would be nice
   $(".grade-save-success").removeClass("grade-save-success", 1000);
 
   //re-setup popover?
   if (this.$cell.is('[data-toggle="popover"]')) {
     this.$cell.popover();
+  }
+
+  if (this._focusAfterSaveComplete) {
+    this.$cell.focus();
+    this._focusAfterSaveComplete = false;
   }
 };
 

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -506,6 +506,9 @@
   font-family: 'gradebook-icons';
   content: '\f057';
   color: #CCC;
+  font-size: 1em;
+  width: 1.2em;
+  text-align: right;
 }
 #gradebookGrades .gb-student-filter-clear:hover {
   text-decoration: none;

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -650,9 +650,10 @@ ul.feedbackPanel {
   content: '\f075';
   color: #CCC;
   position: absolute;
-  right: 5px;
+  right: 4px;
   top: 0;
   font-size: 1em;
+  width: 18px;
 }
 
 /** temporary override for page width **/


### PR DESCRIPTION
This PR delivers a first pass at trying to better comply with accessibility standards and introduce ARIA attributes where applicable.  Changes include:
- compliant table markup for better accessibility e.g. `scope` on column and row headers
  -  TODO: improvement to use `th` element for row headers  
- label elements for all input fields
- ARIA `role` and other markup attributes e.g. `aria-haspopup`
- retain keyboard focus and tab flow when editing a grid cell
