### PR TITLE
Comments in popovers

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
@@ -13,7 +13,7 @@
 	    </a>
 	    <ul class="dropdown-menu dropdown-menu-right" role="menu">
 	   		<li><a wicket:id="viewGradeLog" href="#" role="menuitem" aria-haspopup="true"><wicket:message key="grade.option.viewlog" /></a></li>
-			<li><a wicket:id="editGradeComment" href="#" role="menuitem" aria-haspopup="true"><span wicket:id="editGradeCommentLabel">View / Edit Comments</span></a></li>
+			<li><a wicket:id="editGradeComment" href="#" role="menuitem" aria-haspopup="true" class="gb-edit-comments"><span wicket:id="editGradeCommentLabel">View / Edit Comments</span></a></li>
 	    </ul>
     </div>
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -322,6 +322,8 @@ public class GradeItemCellPanel extends Panel {
 						if(StringUtils.isNotBlank(comment)) {
 							markHasComment(gradeCell);
 							target.add(getParentCellFor(gradeCell));
+							target.appendJavaScript("sakai.gradebookng.spreadsheet.setupCell('" + getParentCellFor(gradeCell).getMarkupId() + "','" + assignmentId + "', '" + studentUuid + "');");
+							refreshPopoverNotifications();
 						};
 						
 					}

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -42,6 +42,7 @@ public class GradeItemCellPanel extends Panel {
 	protected GradebookNgBusinessService businessService;
 		
 	IModel<Map<String,Object>> model;
+	Map<String,Object> modelData;
 	
 	AjaxEditableLabel<String> gradeCell;
 	
@@ -79,7 +80,7 @@ public class GradeItemCellPanel extends Panel {
 		super.onInitialize();
 		
 		//unpack model
-		Map<String,Object> modelData = (Map<String,Object>) this.model.getObject();
+		modelData = (Map<String,Object>) this.model.getObject();
 		final Long assignmentId = (Long) modelData.get("assignmentId");
 		final Double assignmentPoints = (Double) modelData.get("assignmentPoints");
 		final String studentUuid = (String) modelData.get("studentUuid");
@@ -445,7 +446,11 @@ public class GradeItemCellPanel extends Panel {
 	
 	private void refreshPopoverNotifications() {
 		if (!notifications.isEmpty()) {
-			String popoverString = ComponentRenderer.renderComponent(new GradeItemCellPopoverPanel("popover", model, notifications)).toString();
+			modelData.put("comment", comment);
+
+			GradeItemCellPopoverPanel popover = new GradeItemCellPopoverPanel("popover", Model.ofMap(modelData), notifications);
+			String popoverString = ComponentRenderer.renderComponent(popover).toString();
+
 			getParent().add(new AttributeModifier("data-toggle", "popover"));
 			getParent().add(new AttributeModifier("data-trigger", "manual"));
 			getParent().add(new AttributeModifier("data-placement", "bottom"));

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -8,7 +8,13 @@
         <li wicket:id="saveErrorNotification" class="gb-popover-notification-error text-danger"><span wicket:id="message"></span></li>
         <li wicket:id="concurrentEditNotification" class="gb-popover-notification-concurrentedit text-danger"><span wicket:id="message"></span></li>
         <li wicket:id="isOverLimitNotification" class="gb-popover-notification-overlimit text-warning"><span wicket:id="message"></span></li>
-        <li wicket:id="hasCommentNotification" class="gb-popover-notification-has-comment text-info"><span wicket:id="message"></span></li>
+        <li wicket:id="hasCommentNotification" class="gb-popover-notification-has-comment text-info">
+            <span wicket:id="message"></span>
+            <blockquote>
+                <p><span wicket:id="snippet"></span></p>
+            </blockquote>
+            <p><a href="javascript:void(0);" class="gb-popover-edit-comments" aria-haspopup="true"><wicket:message key="comment.option.edit" /></a></p>
+        </li>
         <li wicket:id="isExternalNotification" class="gb-popover-notification-is-external text-info"><span wicket:id="message"></span></li>
     </ul>
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
@@ -3,10 +3,12 @@ package org.sakaiproject.gradebookng.tool.panels;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 
@@ -17,6 +19,8 @@ public class GradeItemCellPopoverPanel extends Panel {
 	public GradeItemCellPopoverPanel(String id, IModel<Map<String,Object>> model, List<GradeItemCellPanel.GradeCellNotification> notifications) {
 		super(id, model);
 
+		final Map<String, Object> modelData = model.getObject();
+
 		WebMarkupContainer saveErrorNotification = new WebMarkupContainer("saveErrorNotification");
 		saveErrorNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.ERROR));
 		saveErrorNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.ERROR.getMessage())));
@@ -26,6 +30,14 @@ public class GradeItemCellPopoverPanel extends Panel {
 		hasCommentNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.HAS_COMMENT));
 		hasCommentNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.HAS_COMMENT.getMessage())));
 		add(hasCommentNotification);
+
+		if (hasCommentNotification.isVisible()) {
+			String comment = (String) modelData.get("comment");
+			hasCommentNotification.add(new Label("snippet", makeSnippet(comment, 100)));
+
+			hasCommentNotification.add(new AttributeModifier("data-assignmentid", (Long) modelData.get("assignmentId")));
+			hasCommentNotification.add(new AttributeModifier("data-studentUuid", (String) modelData.get("studentUuid")));
+		}
 
 		WebMarkupContainer isOverLimitNotification = new WebMarkupContainer("isOverLimitNotification");
 		isOverLimitNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.OVER_LIMIT));
@@ -43,4 +55,27 @@ public class GradeItemCellPopoverPanel extends Panel {
 		add(isExternalNotification);
 	}
 
+
+	private String makeSnippet(String text, int max) {
+		if (text.length() <= max) {
+			return text;
+		}
+
+		int end = text.lastIndexOf(' ', max - 3);
+
+		if (end == -1) {
+			return text.substring(0, max - 3) + "...";
+		}
+
+		int newEnd = end;
+		do {
+			end = newEnd;
+			newEnd = text.indexOf(' ', end + 1);
+			if (newEnd == -1) {
+				newEnd = text.length();
+			}
+		} while ((text.substring(0, newEnd) + "...").length() < max);
+
+		return text.substring(0, end) + "...";
+	}
 }

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1043,34 +1043,56 @@ GradebookSpreadsheet.prototype.setupStudentFilter = function() {
 
 
 GradebookSpreadsheet.prototype.setupPopovers = function() {
-  this.enablePopovers(this.$table);
+  var self = this;
 
-  this.$spreadsheet.on("focus", '[data-toggle="popover"]', function(event) {
-    $(event.target).data("popoverTimeout", setTimeout(function() {
+  self.popoverClicked = false;
+
+  self.enablePopovers(self.$table);
+
+  self.$spreadsheet.on("focus", '[data-toggle="popover"]', function(event) {
+    if (self.$spreadsheet.find(".popover:visible")) {
+      self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
+    }
+    $(event.target).data("popoverShowTimeout", setTimeout(function() {
       $(event.target).popover('show');
     }, 500));
+  });
+
+  self.$spreadsheet.on("click", ".popover", function(event) {
+    self.popoverClicked = true;
+  }).on("click", ":not(.popover)", function(event) {
+    self.popoverClicked = false;
+    if (self.$spreadsheet.find(".popover:visible") && $(event.target).closest(".popover").length == 0) {
+      self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
+    }
+  }).on("click", ".popover .gb-popover-edit-comments", function(event) {
+    var $notification = $(event.target).closest(".gb-popover-notification-has-comment");
+    var cell = self.getCellModelForStudentAndAssignment($notification.data("studentuuid"), $notification.data("assignmentid"));
+    cell.$cell.find(".gb-edit-comments").trigger("click");
   });
 };
 
 
 GradebookSpreadsheet.prototype.enablePopovers = function($target) {
+  var self = this;
   var $popovers = $target.find('[data-toggle="popover"]');
 
   $popovers.popover({
-    trigger: 'focus',
-    delay: {
-      show: 500,
-      hide: 0
-    }
+    trigger: 'manual'
   }).blur(function(event) {
-    clearTimeout($(event.target).data("popoverTimeout"));
+    clearTimeout($(event.target).data("popoverShowTimeout"));
+    $(event.target).data("popoverHideTimeout", setTimeout(function() {
+      if (!self.popoverClicked) {
+        $(event.target).popover("hide");
+      }
+    }, 100));
   });
 
   // Ensure the popover doesn't get in the way of the dropdown menu
   $popovers.find('.btn-group').on("shown.bs.dropdown", function() {
     var $popover = $(this).closest('[data-toggle="popover"]');
     if ($popover.length > 0) {
-      clearTimeout($popover.data("popoverTimeout"));
+      clearTimeout($popover.data("popoverShowTimeout"));
       $popover.popover("hide");
     }
   });

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1069,6 +1069,7 @@ GradebookSpreadsheet.prototype.setupPopovers = function() {
     var $notification = $(event.target).closest(".gb-popover-notification-has-comment");
     var cell = self.getCellModelForStudentAndAssignment($notification.data("studentuuid"), $notification.data("assignmentid"));
     cell.$cell.find(".gb-edit-comments").trigger("click");
+    self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
   });
 };
 
@@ -1110,6 +1111,12 @@ GradebookSpreadsheet.prototype.onReady = function(callback) {
   } else {
     this.$spreadsheet.on("ready.gradebookng", callback);
   }
+};
+
+
+GradebookSpreadsheet.prototype.setupCell = function(cellId, assignmentId, studentUuid) {
+  var cellModel = this.getCellModelForStudentAndAssignment(studentUuid, assignmentId);
+  cellModel.handleSaveComplete(cellId)
 };
 
 

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -545,7 +545,7 @@
 }
 .gb-popover-notifications .gb-popover-notification-overlimit:before {
   font-family: "gradebook-icons";
-  content: "\f071";
+  content: "\f0fe";
 }
 .gb-popover-notifications .gb-popover-notification-has-comment:before {
   font-family: "gradebook-icons";
@@ -635,6 +635,9 @@ ul.feedbackPanel {
   position: absolute;
   left: 20px;
   font-size: 1.4em;
+  height: 1.1em;
+  width: 1.1em;
+  line-height: 1.1em;
 }
 
 .grade-save-error {
@@ -647,6 +650,9 @@ ul.feedbackPanel {
   position: absolute;
   left: 20px;
   font-size: 1.4em;
+  height: 1.1em;
+  width: 1.1em;
+  line-height: 1.1em;
 }
 
 .grade-save-warning {
@@ -659,6 +665,9 @@ ul.feedbackPanel {
   position: absolute;
   left: 20px;
   font-size: 1.4em;
+  height: 1.1em;
+  width: 1.1em;
+  line-height: 1.1em;
 }
 .grade-save-over-limit {
   background-color: #fcf8e3 !important;
@@ -670,6 +679,9 @@ ul.feedbackPanel {
   position: absolute;
   left: 20px;
   font-size: 1.4em;
+  height: 1.1em;
+  width: 1.1em;
+  line-height: 1.1em;
 }
 
 .has-comment > div:after {

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -533,6 +533,7 @@
   max-width: 300px;
 }
 .gb-popover-notifications li {
+  clear: both;
   margin-bottom: 10px;
 }
 .gb-popover-notifications li:before {
@@ -553,6 +554,15 @@
 .gb-popover-notifications .gb-popover-notification-concurrentedit:before {
   font-family: "gradebook-icons";
   content: '\f040';
+}
+.gb-popover-notifications .gb-popover-edit-comments {
+  float: right;
+  font-size: 0.8em;
+}
+.gb-popover-notifications blockquote {
+  margin: 4px 0 0;
+  padding: 5px 10px;
+  font-size: 0.9em;
 }
 /* Wicket Overrides */
 div.wicket-modal div.w_content_3 {


### PR DESCRIPTION
A few things in here...
1. Add a snippet of the grade item comments (truncated to 100 characters at present)
2. Offer an "Edit comment" link in the popover.
   - This change required some rejigging of the popover Javascript to allow clicks within the popover to retain the popover rather than hide it.  
   - Also, I originally had the "Edit comment" link sharing the AjaxLink used in the GradeItemCellPanel, however I had to change this new link to trigger the existing because I couldn't bind the wicket callback to the hidden popover link (it's stored on the cell as a data-content attribute :disappointed:).
3. Fix editing the comment breaking the keyboard navigation.  Upon closing the Comments dialog, the table cell was being replaced but not reinitialised.  I've added a custom Javascript callback to ensure the cell is re-setup will all the necessary key bindings.
4. Clean up of notification icons and match to messages in the popover.
