### PR TITLE
Introduce popover notification on the cell when concurrent edit detected

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -162,7 +162,7 @@ grade.log.none = No grades have been entered for this cell.
 grade.notifications.hascomment = Gradebook item has comments
 grade.notifications.haserror = An error occurred updating the gradebook item
 grade.notifications.overlimit = Gradebook item score is over point value
-grade.notifications.concurrentedit = A concurrent edit has been detected. Please refresh the page for the most up to date scores.
+grade.notifications.concurrentedit = A concurrent edit has been detected. Please reset the tool to view the latest scores.
 grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool 
 
 comment.option.add = Add Comment

--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -163,6 +163,7 @@ grade.notifications.hascomment = Gradebook item has comments
 grade.notifications.haserror = An error occurred updating the gradebook item
 grade.notifications.overlimit = Gradebook item score is over point value
 grade.notifications.concurrentedit = A concurrent edit has been detected. Please reset the tool to view the latest scores.
+grade.notifications.concurrenteditbyuser = <span class="gb-concurrent-edit-user"></span> edited this score at <span class="gb-concurrent-edit-time"></span>.
 grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool 
 
 comment.option.add = Add Comment

--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1030,7 +1030,7 @@ public class GradebookNgBusinessService {
     	 }
     	 
     	 //push the edited cell into the map. It will add/update as required
-		 cells.put(buildCellKey(studentUuid, assignmentId), new GbGradeCell(studentUuid, assignmentId));
+		 cells.put(buildCellKey(studentUuid, assignmentId), new GbGradeCell(studentUuid, assignmentId, currentUser.getDisplayName()));
     	 
     	 //push the new/updated cell map into the main map
     	 notifications.put(currentUser.getEid(), cells);

--- a/tool/src/java/org/sakaiproject/gradebookng/business/model/GbGradeCell.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/model/GbGradeCell.java
@@ -24,11 +24,16 @@ public class GbGradeCell implements Serializable {
 	
 	@Getter @Setter
 	private Date lastUpdated;
-	
-	public GbGradeCell(String studentUuid, long assignmentId){
+
+	@Getter
+	private String lastUpdatedBy;
+
+
+	public GbGradeCell(String studentUuid, long assignmentId, String lastUpdatedBy){
 		this.studentUuid = studentUuid;
 		this.assignmentId = assignmentId;
 		this.lastUpdated = new Date();
+		this.lastUpdatedBy = lastUpdatedBy;
 	}
 	
 }

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -53,9 +53,10 @@
   </form>
 
   <div wicket:id="gradeItemsTogglePanel" id="gradeItemsTogglePanel" style="display: none;"/>
-  <div id="gradeItemsConcurrentUserWarning" class="messageConfirmation" style="display: none;">
-    <wicket:message key="label.concurrentuserwarning" />
-    <span class="gb-message-close"></span>
+  <div id="gradeItemsConcurrentUserWarning" style="display: none;">
+    <ul class="gb-popover-notifications">
+      <li class="gb-popover-notification-concurrentedit text-danger"><wicket:message key="grade.notifications.concurrentedit" /></li>
+    </ul>
   </div>
 </wicket:extend>
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -55,7 +55,10 @@
   <div wicket:id="gradeItemsTogglePanel" id="gradeItemsTogglePanel" style="display: none;"/>
   <div id="gradeItemsConcurrentUserWarning" style="display: none;">
     <ul class="gb-popover-notifications">
-      <li class="gb-popover-notification-concurrentedit text-danger"><wicket:message key="grade.notifications.concurrentedit" /></li>
+      <li class="gb-popover-notification-concurrentedit text-danger">
+        <wicket:message key="grade.notifications.concurrenteditbyuser" /><br/>
+        <wicket:message key="grade.notifications.concurrentedit" />
+      </li>
     </ul>
   </div>
 </wicket:extend>

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -991,23 +991,26 @@ GradebookSpreadsheet.prototype.setupConcurrencyCheck = function() {
   var self = this;
 
   function showConcurrencyNotification(data) {
-    var message = $("#gradeItemsConcurrentUserWarning");
-
     $.each(data, function(i, conflict) {
+      var $message = $("#gradeItemsConcurrentUserWarning").clone();
+      $message.find(".gb-concurrent-edit-user").html(conflict.lastUpdatedBy);
+      $message.find(".gb-concurrent-edit-time").html(new Date(conflict.lastUpdated).toLocaleTimeString());
       var model = self.getCellModelForStudentAndAssignment(conflict.studentUuid, conflict.assignmentId);
       model.$cell.addClass("gb-cell-out-of-date");
       if (model.$cell.data("toggle") == "popover") {
         // append message to current popover
         var existingPopoverContent = $(model.$cell.data("content").trim());
         if (existingPopoverContent.find(".gb-popover-notification-concurrentedit").length == 0) {
-          existingPopoverContent.prepend(message.find(".gb-popover-notification-concurrentedit"));
-          model.$cell.attr("data-content", existingPopoverContent[0].outerHTML);
+          existingPopoverContent.prepend($message.find(".gb-popover-notification-concurrentedit"));
+        } else {
+          existingPopoverContent.find(".gb-popover-notification-concurrentedit").replaceWith($message.find(".gb-popover-notification-concurrentedit"));
         }
+        model.$cell.attr("data-content", existingPopoverContent[0].outerHTML);
       } else {
         // setup a new popover
         model.$cell.
           attr("data-toggle", "popover").
-          data("content", message.html()).
+          data("content", $message.html()).
           data("placement", "bottom").
           data("html", "true").
           data("container", "#gradebookGrades");

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -514,30 +514,6 @@
 #gradeItemsTogglePanel .gradebook-item-category-score-filter.off .gb-show-this-category-score {
   display: block;
 }
-/* Concurrent Users Warning */
-#gradeItemsConcurrentUserWarning {
-  position: fixed;
-  bottom: 0;
-  height: 4em;
-  font-size: 0.9em;
-  left: 10%;
-  width: 80%;
-  z-index: 10000;
-}
-#gradeItemsConcurrentUserWarning .gb-message-close {
-  position: absolute;
-  right: 0;
-  cursor: pointer;
-  position: absolute;
-  right: 4px;
-  top: 50%;
-  font-size: 1.2em;
-  margin-top: -0.6em;
-}
-#gradeItemsConcurrentUserWarning .gb-message-close:before {
-  font-family: 'gradebook-icons';
-  content: '\f00d';
-}
 /* Student filter */
 #gradebookGrades .filtered-by-studentFilter {
   display: none;
@@ -740,4 +716,17 @@ ul.feedbackPanel {
 
 .grade-log-item {
 	margin-bottom: 5px;
+}
+/* Concurrent Users Warning */
+#gradebookGrades .gb-cell-out-of-date > div:before {
+  font-family: "gradebook-icons";
+  content: "\f040";
+  color: #ccc;
+  position: absolute;
+  left: 20px;
+}
+#gradebookGrades .gb-cell-out-of-date:focus > div:before,
+#gradebookGrades .gb-cell-out-of-date.gb-ready-for-edit > div:before,
+#gradebookGrades .gb-cell-out-of-date.gb-cell-editing > div:before {
+  color: #a94442;
 }


### PR DESCRIPTION
Delivers #123.

This new behaviour updates the existing concurrent edit poll to target the particular score that is now out of date.

The poll runs every 6 seconds.

When a concurrent edit is detected, the cell is give a CSS class `gb-cell-out-of-date` to allow styling.  Currently we show a grey pencil icon to the left of the score.  When the cell is focused, the pencil becomes red and an popover notification is displayed with the text "A concurrent edit has been detected. Please reset the tool to view the latest scores.".

To ensure bypass of the browser cache, I've also added a cache breaker to the AJAX poll GET.
