### PR TITLE
Popover and concurrency notification things

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -167,7 +167,7 @@ grade.notifications.hascomment = Gradebook item has comments
 grade.notifications.haserror = An error occurred updating the gradebook item
 grade.notifications.overlimit = Gradebook item score is over point value
 grade.notifications.concurrentedit = A concurrent edit has been detected. Please reset the tool to view the latest scores.
-grade.notifications.concurrenteditbyuser = <span class="gb-concurrent-edit-user"></span> edited this score at <span class="gb-concurrent-edit-time"></span>.
+grade.notifications.concurrenteditbyuser = <span class="gb-concurrent-edit-user">{0}</span> edited this score at <span class="gb-concurrent-edit-time">{1}</span>. Please reset the tool to view the latest scores.
 grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool 
 
 comment.option.add = Add Comment

--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1098,7 +1098,7 @@ public class GradebookNgBusinessService {
     	 String currentUserId = this.getCurrentUser().getEid();
     	     	 
     	 //get the notifications for this gradebook
-    	 Map<String,Map<String,GbGradeCell>> notifications = (Map<String,Map<String,GbGradeCell>>) cache.get(gradebookUid);
+    	 Map<String,Map<String,GbGradeCell>> notifications = new HashMap<String,Map<String,GbGradeCell>>((Map<String,Map<String,GbGradeCell>>) cache.get(gradebookUid));
     	 
     	 List<GbGradeCell> rval = new ArrayList<>();
     	 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -56,8 +56,7 @@
   <div id="gradeItemsConcurrentUserWarning" style="display: none;">
     <ul class="gb-popover-notifications">
       <li class="gb-popover-notification-concurrentedit text-danger">
-        <wicket:message key="grade.notifications.concurrenteditbyuser" /><br/>
-        <wicket:message key="grade.notifications.concurrentedit" />
+        <wicket:message key="grade.notifications.concurrenteditbyuser" />
       </li>
     </ul>
   </div>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -3,7 +3,7 @@
 
 <body>
 <wicket:panel>
-
+    <a wicket:id="closePopoverLink" href="javascript:void(0);" class="gb-popover-close"></a>
     <ul class="gb-popover-notifications">
         <li wicket:id="saveErrorNotification" class="gb-popover-notification-error text-danger"><span wicket:id="message"></span></li>
         <li wicket:id="concurrentEditNotification" class="gb-popover-notification-concurrentedit text-danger"><span wicket:id="message"></span></li>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
@@ -21,6 +21,11 @@ public class GradeItemCellPopoverPanel extends Panel {
 
 		final Map<String, Object> modelData = model.getObject();
 
+		WebMarkupContainer closePopoverLink = new WebMarkupContainer("closePopoverLink");
+		closePopoverLink.add(new AttributeModifier("data-assignmentid", (Long) modelData.get("assignmentId")));
+		closePopoverLink.add(new AttributeModifier("data-studentUuid", (String) modelData.get("studentUuid")));
+		add(closePopoverLink);
+
 		WebMarkupContainer saveErrorNotification = new WebMarkupContainer("saveErrorNotification");
 		saveErrorNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.ERROR));
 		saveErrorNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.ERROR.getMessage())));

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1135,6 +1135,11 @@ GradebookSpreadsheet.prototype.setupPopovers = function() {
   self.enablePopovers(self.$table);
 
   self.$spreadsheet.on("focus", '[data-toggle="popover"]', function(event) {
+    if (self.suppressPopover) {
+      self.suppressPopover = false;
+      return;
+    }
+
     if (self.$spreadsheet.find(".popover:visible")) {
       self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
     }
@@ -1146,15 +1151,24 @@ GradebookSpreadsheet.prototype.setupPopovers = function() {
   self.$spreadsheet.on("click", ".popover", function(event) {
     self.popoverClicked = true;
   }).on("click", ":not(.popover)", function(event) {
-    self.popoverClicked = false;
-    if (self.$spreadsheet.find(".popover:visible") && $(event.target).closest(".popover").length == 0) {
-      self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
+    if ($(event.target).closest(".popover").length == 0) {
+      self.popoverClicked = false;
+      if (self.$spreadsheet.find(".popover:visible") && $(event.target).closest(".popover").length == 0) {
+        self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
+      }
     }
   }).on("click", ".popover .gb-popover-edit-comments", function(event) {
     var $notification = $(event.target).closest(".gb-popover-notification-has-comment");
     var cell = self.getCellModelForStudentAndAssignment($notification.data("studentuuid"), $notification.data("assignmentid"));
     cell.$cell.find(".gb-edit-comments").trigger("click");
     self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
+  }).on("click", ".popover .gb-popover-close", function(event) {
+    var $link = $(this);
+    var cell = self.getCellModelForStudentAndAssignment($link.data("studentuuid"), $link.data("assignmentid"));
+    self.$spreadsheet.find('[data-toggle="popover"]').popover("hide");
+    self.suppressPopover = true;
+    self.popoverClicked = false;
+    cell.$cell.focus();
   });
 };
 
@@ -1168,13 +1182,14 @@ GradebookSpreadsheet.prototype.enablePopovers = function($target) {
   $popovers.popover({
     trigger: 'manual'
   }).blur(function(event) {
-    console.log(event.target);
     clearTimeout($(event.target).data("popoverShowTimeout"));
     $(event.target).data("popoverHideTimeout", setTimeout(function() {
       if (!self.popoverClicked) {
         $(event.target).popover("hide");
       }
     }, 100));
+  }).on("hidden.bs.popover", function() {
+    self.popoverClicked = false;
   });
 
   // Ensure the popover doesn't get in the way of the dropdown menu

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -572,6 +572,13 @@
   padding: 5px 10px;
   font-size: 0.9em;
 }
+.gb-popover-close {
+  float: right;
+}
+.gb-popover-close:before {
+  font-family: "gradebook-icons";
+  content: "\f00d";
+}
 /* Wicket Overrides */
 div.wicket-modal div.w_content_3 {
   border: none; /** don't want border wrapping content inside the modal **/


### PR DESCRIPTION
- wording of the concurrent user notification (as a result of the poll)
- add close button to the popover
- fix sticky popovers
- fix concurrent notifications #155

@steveswinsburg it wasn't clear how to include the user name and timestamp on the concurrency notification after a failed save.  The method `GradeSaveResponse result = businessService.saveGrade(...)` doesn't currently have all the data we need.  Perhaps need a custom exception or enum with some smarts (maybe an object)?
