### PR TITLE
Add Sakai datepicker to the Add/Edit Assignment form for duedate

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.html
@@ -5,8 +5,6 @@
 	<title><wicket:message key="app.title" /></title>
 	<wicket:head>
 		<wicket:link>
-			<!-- Include jQuery as Bootstrap requires it -->
-			<script type="text/javascript" src="/library/js/jquery/jquery-1.9.1.min.js"></script>
 			<!-- Include Bootstrap -->
 			<script type="text/javascript" src="/library/js/bootstrap/3.3.2/js/bootstrap.min.js"></script>
 			<link rel="stylesheet" href="/library/js/bootstrap/3.3.2/css/bootstrap.min.css" />

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -10,7 +10,9 @@ import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnLoadHeaderItem;
+import org.apache.wicket.markup.head.PriorityHeaderItem;
 import org.apache.wicket.markup.head.StringHeaderItem;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.IHeaderContributor;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.WebPage;
@@ -188,6 +190,8 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		//get the Sakai skin header fragment from the request attribute
 		HttpServletRequest request = (HttpServletRequest)getRequest().getContainerRequest();
 		
+		response.render(new PriorityHeaderItem(JavaScriptHeaderItem.forReference(getApplication().getJavaScriptLibrarySettings().getJQueryReference())));
+
 		response.render(StringHeaderItem.forString((String)request.getAttribute("sakai.html.head")));
 		response.render(OnLoadHeaderItem.forScript("setMainFrameHeight( window.name )"));
 		

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/EditGradebookItemPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/EditGradebookItemPage.html
@@ -3,6 +3,13 @@
 	xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
 
 <body>
+	<wicket:head>
+		<wicket:link>
+			<!-- Include Sakai Date Picker -->
+			<script src="/library/js/jquery/ui/1.11.3/jquery-ui.min.js"></script>
+			<script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js"></script>
+		</wicket:link>
+	</wicket:head>
 	<wicket:extend>
 
 		<form class="form-horizontal" wicket:id="form">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -4,9 +4,12 @@
 
 <wicket:head>
   <wicket:link>
-    <!-- Drag and Drop (requires jQueryUI) -->
+    <!-- Drag and Drop/Date Picker (requires jQueryUI) -->
     <script src="/library/js/jquery/ui/1.11.3/jquery-ui.min.js"></script>
-    
+
+    <!-- Include Sakai Date Picker -->
+    <script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js"></script>
+
     <!-- GradebookNG Grade specific behaviour -->
     <link rel="stylesheet" type="text/css" href="/gradebookng-tool/styles/gradebook-grades.css"/>
     <script src="/gradebookng-tool/scripts/gradebook-grades.js"></script>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.html
@@ -5,6 +5,10 @@
 
 <wicket:head>
   <wicket:link>
+    <!-- Include Sakai Date Picker -->
+    <script src="/library/js/jquery/ui/1.11.3/jquery-ui.min.js"></script>
+    <script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js"></script>
+
     <link rel="stylesheet" type="text/css" href="/gradebookng-tool/styles/gradebook-importexport.css"/>
   </wicket:link>
 </wicket:head>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
@@ -114,7 +114,7 @@ public class StudentPage extends BasePage {
 			return getString("label.studentsummary.noduedate");
 		}
 		
-		SimpleDateFormat df = new SimpleDateFormat("dd/MM/yy");
+		SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy");
     	return df.format(date);
 	}
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.html
@@ -9,7 +9,7 @@
 					<wicket:message key="label.addgradeitem.title" />
 				</label>
 				<div class="col-xs-7">
-     				<input wicket:id="title" type="text" class="form-control" placeholder="Week 1 assignment" />
+     				<input wicket:id="title" type="text" class="form-control" />
    	 			</div>
 			</div>
 			<div class="form-group form-group-sm">
@@ -17,7 +17,7 @@
 					<wicket:message key="label.addgradeitem.points" />
 				</label>
 				<div class="col-xs-2">
-					<input wicket:id="points" type="text" class="form-control" placeholder="100" />
+					<input wicket:id="points" type="text" class="form-control" />
 				</div>
 			</div>
 			<div class="form-group form-group-sm">
@@ -35,8 +35,38 @@
 					<wicket:message key="label.addgradeitem.due" />
 				</label>
 				<div class="col-xs-4">
-					<input wicket:id="duedate" type="text" class="form-control" placeholder="dd/mm/yy" aria-describedby="duedate-help"/>
-					<span id="duedate-help" class="help-block"><wicket:message key="label.addgradeitem.due.help" /></span>
+                    <div class="input-group">
+                        <input wicket:id="duedate" type="text" class="form-control gb-datepicker" placeholder="mm/dd/yyyy" aria-describedby="duedate-help"/>
+                        <span class="input-group-btn">
+                            <button class="btn btn-sm btn-default invoke-datepicker-btn" type="button"><span class="glyphicon glyphicon-calendar"></span></button>
+                            <button class="btn btn-sm btn-default clear-datepicker-btn" type="button"><span class="glyphicon glyphicon-remove"></span></button>
+                        </span>
+                    </div>
+                    <script>
+                        var initDatePickers = function () {
+                            $('.gb-datepicker').each(function() {
+                                var $datepicker = $(this);
+    
+                                localDatePicker({
+                                    input: '#' + $datepicker.attr('id'),
+                                    useTime: 0,
+                                    icon: 0,
+                                    parseFormat: 'DD/MM/YYYY'
+                                })
+    
+                                // setup input button to trigger date-time picker
+                                $datepicker.siblings().find(".invoke-datepicker-btn").click(function() {
+                                    $datepicker.focus();
+                                });
+    
+                                // add clear action if present
+                                $datepicker.siblings().find(".clear-datepicker-btn").click(function() {
+                                    $datepicker.val("");
+                                });
+                            });
+                        };
+                        initDatePickers();
+                    </script>
 				</div>
 			</div>
 			<div class="form-group form-group-sm">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
@@ -35,7 +35,7 @@ public class AddGradeItemPanelContent extends Panel {
 
         add(new TextField("title", new PropertyModel(assignment, "name")));
         add(new TextField("points", new PropertyModel(assignment, "points")));
-        add(new DateTextField("duedate", new PropertyModel(assignment, "dueDate"), "MM/DD/yy"));
+        add(new DateTextField("duedate", new PropertyModel(assignment, "dueDate"), "MM/dd/yyyy"));
 
         List<CategoryDefinition> categories = businessService.getGradebookCategories();
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -268,7 +268,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 			return getString("label.noduedate");
 		}
 		
-		SimpleDateFormat df = new SimpleDateFormat("dd/MM/yy");
+		SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy");
     	return df.format(assignmentDueDate);
 	}
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
@@ -108,7 +108,7 @@ public class GradeLogPanel extends Panel {
 	private String formatDate(Date date) {
 		//TODO locale formatting via ResourceLoader
 		
-		SimpleDateFormat df = new SimpleDateFormat("dd/MM/yy HH:mm");
+		SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy HH:mm");
     	return df.format(date);
 	}
 	

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
@@ -132,7 +132,7 @@ public class StudentGradeSummaryPanel extends Panel {
 			return getString("label.studentsummary.noduedate");
 		}
 		
-		SimpleDateFormat df = new SimpleDateFormat("dd/MM/yy");
+		SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy");
     	return df.format(date);
 	}
 	

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -737,3 +737,7 @@ ul.feedbackPanel {
 #gradebookGrades .gb-cell-out-of-date.gb-cell-editing > div:before {
   color: #a94442;
 }
+/* Datepicker */
+.ui-datepicker {
+  z-index: 50000 !important;
+}


### PR DESCRIPTION
Heya @steveswinsburg, I think I finally figured out a way around the conflicting jQuerys! By marking Wicket's jQuery 1.11.1 as a `PriorityHeaderItem` it should always be ordered to the top of the header resource list.  So we won't need to include jQuery in our `wicket:head` as the Wicket jQuery should win out.

Also, I went through and made the date format consistent MM/dd/yyyy.  Should this be a locale or a configurable string?

Thanks!
