### PR TITLE
Ensure new assignment is added to the end of the list

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -791,7 +791,22 @@ public class GradebookNgBusinessService {
         
     	if(gradebook != null) {
             String gradebookId = gradebook.getUid();
-            return this.gradebookService.addAssignment(gradebookId, assignment);
+
+            Long assignmentId = this.gradebookService.addAssignment(gradebookId, assignment);
+
+            // Force the assignment to sit at the end of the list
+            if (assignment.getSortOrder() == null) {
+                List<Assignment> allAssignments = this.gradebookService.getAssignments(gradebookId);
+                int nextSortOrder = allAssignments.size();
+                for (Assignment anotherAssignment : allAssignments) {
+                    if (anotherAssignment.getSortOrder() != null && anotherAssignment.getSortOrder() >= nextSortOrder) {
+                        nextSortOrder = anotherAssignment.getSortOrder() + 1;
+                    }
+                }
+                updateAssignmentOrder(assignmentId, nextSortOrder);
+            }
+
+            return assignmentId;
             
             //TODO wrap this so we can catch any runtime exceptions
         }


### PR DESCRIPTION
Hi @steveswinsburg, I noticed that sometimes a new assignment was not being inserted to the right of the last assignment.  It seems the sortOrder is not being set by default.

This patch forces a newly created Assignment to be last in the list by setting its sort order accordingly.

Hopefully that gets it :/
