### PR TITLE
Fix erroneous concurrent error 

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -169,7 +169,8 @@ grade.notifications.haserror = An error occurred updating the gradebook item
 grade.notifications.overlimit = Gradebook item score is over point value
 grade.notifications.concurrentedit = A concurrent edit has been detected. Please reset the tool to view the latest scores.
 grade.notifications.concurrenteditbyuser = <span class="gb-concurrent-edit-user">{0}</span> edited this score at <span class="gb-concurrent-edit-time">{1}</span>. Please reset the tool to view the latest scores.
-grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool 
+grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool
+grade.notifications.invalid = Gradebook item score must be a positive number or decimal
 
 comment.option.add = Add Comment
 comment.option.edit = Edit Comment

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -57,7 +57,8 @@ public class GradeItemCellPanel extends Panel {
 		OVER_LIMIT("grade.notifications.overlimit"),
 		HAS_COMMENT("grade.notifications.hascomment"),
 		CONCURRENT_EDIT("grade.notifications.concurrentedit"),
-		ERROR("grade.notifications.haserror");
+		ERROR("grade.notifications.haserror"),
+		INVALID("grade.notifications.invalid");
 
 		private String message;
 
@@ -161,7 +162,7 @@ public class GradeItemCellPanel extends Panel {
 					
 					if(!validator.isValid(newGrade)) {
 						markWarning(this);
-						//TODO add the message
+						this.getLabel().setDefaultModelObject(this.originalGrade);
 					} else {
 						
 						//for concurrency, get the original grade we have in the UI and pass it into the service as a check
@@ -192,13 +193,13 @@ public class GradeItemCellPanel extends Panel {
 							default:
 								throw new UnsupportedOperationException("The response for saving the grade is unknown.");
 						}
+
+
+						//format the grade for subsequent display and update the model
+						String formattedGrade = formatGrade(newGrade);
+						this.getLabel().setDefaultModelObject(formattedGrade);
 					}
-								
-					//format the grade for subsequent display and update the model
-					String formattedGrade = formatGrade(newGrade);
-					
-					this.getLabel().setDefaultModelObject(formattedGrade);
-					
+
 					//refresh the components we need
 					target.addChildren(getPage(), FeedbackPanel.class);
 					target.add(getParentCellFor(this));
@@ -399,6 +400,7 @@ public class GradeItemCellPanel extends Panel {
 	private void markWarning(Component gradeCell) {
 		this.gradeSaveStyle = GradeCellSaveStyle.WARNING;
 		styleGradeCell(gradeCell);
+		notifications.add(GradeCellNotification.INVALID);
 	}
 	
 	private void markOverLimit(Component gradeCell) {

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -1,6 +1,7 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -156,7 +157,9 @@ public class GradeItemCellPanel extends Panel {
 					super.onSubmit(target);
 					
 					String newGrade = this.getEditor().getValue();
-										
+
+					clearNotifications();
+
 					//perform validation here so we can bypass the backend
 					DoubleValidator validator = new DoubleValidator();
 					
@@ -414,6 +417,13 @@ public class GradeItemCellPanel extends Panel {
 		notifications.add(GradeCellNotification.HAS_COMMENT);
 	}
 	
+	private void clearNotifications() {
+		notifications.clear();
+		if(StringUtils.isNotBlank(comment)) {
+			markHasComment(gradeCell);
+		}
+	}
+	
 	/**
 	 * Builder for styling the cell. Aware of the cell 'save style' as well as if it has comments and adds styles accordingly
 	 * @param gradeCell the cell to style
@@ -467,7 +477,15 @@ public class GradeItemCellPanel extends Panel {
 	
 	
 	private void refreshPopoverNotifications() {
-		if (!notifications.isEmpty()) {
+		if (notifications.isEmpty()) {
+			String[] popoverAttributesToRemove = {"data-toggle", "data-trigger", "data-placement", "data-html", "data-container", "data-content"};
+			List<AttributeModifier> attributes = getParent().getBehaviors(AttributeModifier.class);
+			for (AttributeModifier attribute : attributes) {
+				if (Arrays.asList(popoverAttributesToRemove).contains(attribute.getAttribute())) {
+					getParent().remove(attribute);
+				}
+			}
+		} else {
 			modelData.put("comment", comment);
 
 			GradeItemCellPopoverPanel popover = new GradeItemCellPopoverPanel("popover", Model.ofMap(modelData), notifications);

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -6,6 +6,7 @@
     <a wicket:id="closePopoverLink" href="javascript:void(0);" class="gb-popover-close"></a>
     <ul class="gb-popover-notifications">
         <li wicket:id="saveErrorNotification" class="gb-popover-notification-error text-danger"><span wicket:id="message"></span></li>
+        <li wicket:id="isInvalidNotification" class="gb-popover-notification-invalid text-warning"><span wicket:id="message"></span></li>
         <li wicket:id="concurrentEditNotification" class="gb-popover-notification-concurrentedit text-danger"><span wicket:id="message"></span></li>
         <li wicket:id="isOverLimitNotification" class="gb-popover-notification-overlimit text-warning"><span wicket:id="message"></span></li>
         <li wicket:id="hasCommentNotification" class="gb-popover-notification-has-comment text-info">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
@@ -58,6 +58,11 @@ public class GradeItemCellPopoverPanel extends Panel {
 		isExternalNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.IS_EXTERNAL));
 		isExternalNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.IS_EXTERNAL.getMessage())));
 		add(isExternalNotification);
+
+		WebMarkupContainer isInvalidNotification = new WebMarkupContainer("isInvalidNotification");
+		isInvalidNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.INVALID));
+		isInvalidNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.INVALID.getMessage())));
+		add(isInvalidNotification);
 	}
 
 

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -551,6 +551,10 @@
   font-family: "gradebook-icons";
   content: "\f06a";
 }
+.gb-popover-notifications .gb-popover-notification-invalid:before {
+  font-family: "gradebook-icons";
+  content: "\f071";
+}
 .gb-popover-notifications .gb-popover-notification-overlimit:before {
   font-family: "gradebook-icons";
   content: "\f0fe";


### PR DESCRIPTION
Fixes #166 (except for wording change?)

Retain the originalGrade value when an invalid score is detected. Also show a new popover message to notify user of problem value.

Also fix issue whereby error/warning popovers were sticking around after the cell had been corrected. E.g. enter score over limit; over point value popover displays; correct to be below limit; over point value popover remains.
