### PR TITLE
Student drilldown enhancements

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -112,6 +112,7 @@ label.studentsummary.categoryscoreifhiddenassignment = N/A *
 label.studentsummary.categoryscorenotreleased = * There are items in within this category that have not yet been released to students.
 label.studentsummary.coursegradenotreleased = Not Yet Released
 label.studentsummary.coursegradenotreleasedmessage = * The final course grade has not been released to students. To release final course grade to students, select "Display Final Course Grades to Students" within Settings.
+label.studentsummary.categoryweight=({0})
 column.header.studentsummary.gradebookitem = Gradebook Item
 column.header.studentsummary.duedate = Due Date
 column.header.studentsummary.grade = Grade

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -97,7 +97,7 @@ public class GradebookPage extends BasePage {
 		form.add(addGradeItemWindow);
 		
 		studentGradeSummaryWindow = new ModalWindow("studentGradeSummaryWindow");
-		studentGradeSummaryWindow.setMaskType(MaskType.SEMI_TRANSPARENT);
+		studentGradeSummaryWindow.setMaskType(MaskType.TRANSPARENT);
 		studentGradeSummaryWindow.setResizable(false);
 		studentGradeSummaryWindow.setUseInitialHeight(false);
 		studentGradeSummaryWindow.setWidthUnit("%");

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -101,7 +101,7 @@ public class GradebookPage extends BasePage {
 		studentGradeSummaryWindow.setResizable(false);
 		studentGradeSummaryWindow.setUseInitialHeight(false);
 		studentGradeSummaryWindow.setWidthUnit("%");
-		studentGradeSummaryWindow.setInitialWidth(95);
+		studentGradeSummaryWindow.setInitialWidth(70);
 		form.add(studentGradeSummaryWindow);
 		
 		updateUngradedItemsWindow = new ModalWindow("updateUngradedItemsWindow");

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AjaxBootstrapTabbedPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AjaxBootstrapTabbedPanel.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd" >
+<body>
+
+	<wicket:panel>
+
+		<div class="tabbable tabs-left">
+			<ul class="nav nav-tabs" wicket:id="tabs-container">
+				<li wicket:id="tabs">
+					<a data-toggle="tab" href="#" wicket:id="link"><span wicket:id="title">[tab title]</span></a>
+				</li>
+			</ul>
+			<div class="tab-content">
+				<div wicket:id="panel" class="tab-pane active">[tab]</div>
+			</div>
+		</div>
+
+	</wicket:panel>
+
+</body>
+</html>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AjaxBootstrapTabbedPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AjaxBootstrapTabbedPanel.java
@@ -1,0 +1,28 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import org.apache.wicket.extensions.ajax.markup.html.tabs.AjaxTabbedPanel;
+import org.apache.wicket.extensions.markup.html.tabs.ITab;
+import org.apache.wicket.model.IModel;
+
+import java.util.List;
+
+public class AjaxBootstrapTabbedPanel<T extends ITab> extends AjaxTabbedPanel<T> {
+
+	public AjaxBootstrapTabbedPanel(String id, List<T> tabs) {
+		super(id, tabs);
+	}
+
+	public AjaxBootstrapTabbedPanel(String id, List<T> tabs, IModel<Integer> model) {
+		super(id, tabs, model);
+	}
+
+	@Override
+	protected String getSelectedTabCssClass() {
+		return "active";
+	}
+
+	@Override
+	protected String getTabContainerCssClass() {
+		return "nav nav-tabs";
+	}
+}

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -5,8 +5,8 @@
 	<wicket:panel>
 		<div class="gb-summary-grade-panel">
 			<div class="row gb-summary-course-grade">
-				<div class="gb-summary-course-grade-label col-md-3"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
-				<div class="gb-summary-course-grade-value col-md-9"><span wicket:id="courseGrade">B+</span> <span wicket:id="courseGradeNotReleasedFlag"></span></div>
+				<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
+				<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span> <span wicket:id="courseGradeNotReleasedFlag"></span></div>
 			</div>
 	
 			<div class="row">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -21,7 +21,7 @@
 			<table class="table table-bordered table-striped table-hover table-condensed">
 				<thead>
 				<tr>
-					<th colspan="2"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
+					<th><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.duedate" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.grade" /></th>
 					<th><wicket:message key="column.header.studentsummary.comments" /></th>
@@ -29,7 +29,7 @@
 				</thead>
 				<tbody wicket:id="categoriesList">
 				<tr class="gb-summary-category-row">
-					<td colspan="3">
+					<td colspan="2">
 						<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
 						<span wicket:id="category" class="gb-summary-category-name"></span>
 						<span wicket:id="categoryWeight" class="gb-summary-category-weight"></span>
@@ -38,11 +38,13 @@
 					<td></td>
 				</tr>
 				<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
-					<td class="gb-summary-grade-title" wicket:id="title"></td>
-					<td class="col-md-1 gb-summary-grade-flags" wicket:id="flags">
-						<span wicket:id="isExtraCredit" class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracredit"></span>
-						<span wicket:id="isNotCounted" class="gb-flag-not-counted" wicket:message="title:label.gradeitem.notcounted"></span>
-						<span wicket:id="isNotReleased" class="gb-flag-not-released" wicket:message="title:label.gradeitem.notreleased"></span>
+					<td>
+						<span class="gb-summary-grade-title" wicket:id="title"></span>
+						<span class="gb-summary-grade-flags" wicket:id="flags">
+							<span wicket:id="isExtraCredit" class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracredit"></span>
+							<span wicket:id="isNotCounted" class="gb-flag-not-counted" wicket:message="title:label.gradeitem.notcounted"></span>
+							<span wicket:id="isNotReleased" class="gb-flag-not-released" wicket:message="title:label.gradeitem.notreleased"></span>
+						</span>
 					</td>
 					<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
 					<td class="gb-summary-grade-score">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -24,7 +24,6 @@
 					<th colspan="2"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.duedate" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.grade" /></th>
-					<th class="col-md-1"><wicket:message key="column.header.studentsummary.weight" /></th>
 					<th><wicket:message key="column.header.studentsummary.comments" /></th>
 				</tr>
 				</thead>
@@ -32,10 +31,10 @@
 				<tr class="gb-summary-category-row">
 					<td colspan="3">
 						<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
-						<span wicket:id="category"></span>
+						<span wicket:id="category" class="gb-summary-category-name"></span>
+						<span wicket:id="categoryWeight" class="gb-summary-category-weight"></span>
 					</td>
 					<td class="gb-summary-category-grade" wicket:id="categoryGrade"></td>
-					<td class="gb-summary-category-weight" wicket:id="categoryWeight"></td>
 					<td></td>
 				</tr>
 				<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
@@ -50,7 +49,6 @@
 						<span class="gb-summary-grade-score-raw" wicket:id="grade"></span>
 						<span class="gb-summary-grade-score-outof" wicket:id="outOf"></span>
 					</td>
-					<td class="gb-summary-grade-weight" wicket:id="weight"></td>
 					<td class="gb-summary-grade-comments" wicket:id="comments"></td>
 				</tr>
 				</tbody>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -124,9 +124,12 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 
 						String weight = "";
 						if (categoryDefinition.getWeight() == null) {
-							weight = FormatHelper.formatDoubleAsPercentage(categoryDefinition.getWeight());
+							categoryItem.add(new Label("categoryWeight", ""));
+						} else {
+							weight = FormatHelper.formatDoubleAsPercentage(categoryDefinition.getWeight() * 100);
+							categoryItem.add(new Label("categoryWeight", new StringResourceModel("label.studentsummary.categoryweight", null, new Object[] {weight})));
 						}
-						categoryItem.add(new Label("categoryWeight", weight));
+						
 					} else {
 						categoryScoreHidden[0] = true;
 						categoryItem.add(new Label("categoryGrade", getString("label.studentsummary.categoryscoreifhiddenassignment")));
@@ -201,7 +204,6 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 								return rawGrade != "";
 							}
 						});
-						assignmentItem.add(new Label("weight", assignment.getWeight()));
 						assignmentItem.add(new Label("comments", comment));
 					}
 				});

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.html
@@ -6,24 +6,11 @@
 
 		<h2 wicket:id="heading">Grade Report for Tony Stark</h2>
 
-		<ul id="studentGradeSummaryTabs" class="nav nav-pills" role="tablist">
-			<li role="presentation" class="active"><a href="#instructorView"><wicket:message key="label.studentsummary.instructorviewtab" /></a></li>
-			<li role="presentation"><a href="#studentView"><wicket:message key="label.studentsummary.studentviewtab" /></a></li>
-		</ul>
+		<span wicket:id="tabs" class="tabpanel">[tabbed panel will be here]</span>
 
-		<div class="tab-content">
-			<div role="tabpanel" class="tab-pane fade in active" id="instructorView">
-
-				<div wicket:id="instructorView"></div>
-
-				<div class="gb-summary-navigate-students row">
-					<a class="gb-summary-previous-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.previous" /></a>
-					<a class="gb-summary-next-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.next" /></a>
-				</div>
-			</div>
-			<div role="tabpanel" class="tab-pane fade" id="studentView">
-				<div wicket:id="studentView"></div>
-			</div>
+		<div wicket:id="studentNavigation" class="row">
+			<a class="gb-summary-previous-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.previous" /></a>
+			<a class="gb-summary-next-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.next" /></a>
 		</div>
 
 		<div class="gb-summary-modal-actions row">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.html
@@ -3,18 +3,19 @@
 
 <body>
 	<wicket:panel>
+		<div class="gb-grade-summary-content">
+			<h2 wicket:id="heading">Grade Report for Tony Stark</h2>
 
-		<h2 wicket:id="heading">Grade Report for Tony Stark</h2>
+			<span wicket:id="tabs" class="tabpanel">[tabbed panel will be here]</span>
 
-		<span wicket:id="tabs" class="tabpanel">[tabbed panel will be here]</span>
+			<div class="gb-summary-modal-actions row">
+				<div wicket:id="studentNavigation" class="row">
+					<a class="gb-summary-previous-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.previous" /></a>
+					<a class="gb-summary-next-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.next" /></a>
+				</div>
 
-		<div wicket:id="studentNavigation" class="row">
-			<a class="gb-summary-previous-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.previous" /></a>
-			<a class="gb-summary-next-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.next" /></a>
-		</div>
-
-		<div class="gb-summary-modal-actions row">
-			<button type="submit" class="btn btn-secondary gb-summary-close" wicket:id="done"><wicket:message key="button.done" /></button>
+				<button type="submit" class="btn btn-secondary gb-summary-close" wicket:id="done"><wicket:message key="button.done" /></button>
+			</div>
 		</div>
 	</wicket:panel>
 </body>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
@@ -86,10 +86,13 @@ public class StudentGradeSummaryPanel extends Panel {
 			protected void onAjaxUpdate(AjaxRequestTarget target) {
 				super.onAjaxUpdate(target);
 
-				studentNavigation.setVisible(getSelectedTab() == 0);
+				boolean showingInstructorView = (getSelectedTab() == 0);
+				boolean showingStudentView = (getSelectedTab() == 1);
+
+				studentNavigation.setVisible(showingInstructorView);
 				target.add(studentNavigation);
 
-				target.appendJavaScript("new GradebookGradeSummary($(\"#"+getParent().getMarkupId()+"\"));");
+				target.appendJavaScript("new GradebookGradeSummary($(\"#"+getParent().getMarkupId()+"\"), " + showingStudentView + ");");
 			}
 		});
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
@@ -1,18 +1,24 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.extensions.ajax.markup.html.tabs.AjaxTabbedPanel;
+import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +42,7 @@ public class StudentGradeSummaryPanel extends Panel {
 		super(id, model);
 		
 		this.window = window;
+		this.setOutputMarkupId(true);
 	}
 
 	@Override
@@ -56,8 +63,35 @@ public class StudentGradeSummaryPanel extends Panel {
 			}
 		});
 
-		add(new StudentGradeSummaryGradesPanel("instructorView", (IModel<Map<String,Object>>) getDefaultModel(), StudentGradeSummaryGradesPanel.VIEW.INSTRUCTOR));
-		add(new StudentGradeSummaryGradesPanel("studentView", (IModel<Map<String,Object>>) getDefaultModel(), StudentGradeSummaryGradesPanel.VIEW.STUDENT));
+		final WebMarkupContainer studentNavigation = new WebMarkupContainer("studentNavigation");
+		studentNavigation.setOutputMarkupPlaceholderTag(true);
+		add (studentNavigation);
+		
+		List tabs=new ArrayList();
+
+		tabs.add(new AbstractTab(new Model<String>(getString("label.studentsummary.instructorviewtab"))) {
+			public Panel getPanel(String panelId) { return new StudentGradeSummaryGradesPanel(panelId, (IModel<Map<String,Object>>) getDefaultModel(), StudentGradeSummaryGradesPanel.VIEW.INSTRUCTOR); }
+		});
+		tabs.add(new AbstractTab(new Model<String>(getString("label.studentsummary.studentviewtab"))) {
+			public Panel getPanel(String panelId) { return new StudentGradeSummaryGradesPanel(panelId, (IModel<Map<String,Object>>) getDefaultModel(), StudentGradeSummaryGradesPanel.VIEW.STUDENT); }
+		});
+
+		add(new AjaxBootstrapTabbedPanel("tabs", tabs) {
+			@Override
+			protected String getTabContainerCssClass() {
+				return "nav nav-pills";
+			}
+
+			@Override
+			protected void onAjaxUpdate(AjaxRequestTarget target) {
+				super.onAjaxUpdate(target);
+
+				studentNavigation.setVisible(getSelectedTab() == 0);
+				target.add(studentNavigation);
+
+				target.appendJavaScript("new GradebookGradeSummary($(\"#"+getParent().getMarkupId()+"\"));");
+			}
+		});
 
 		add(new Label("heading", new StringResourceModel("heading.studentsummary", null, new Object[]{ displayName, eid })));
 	}

--- a/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -5,19 +5,30 @@
 /**************************************************************************************
  * A GradebookGradeSummary to encapsulate all the grade summary content behaviours 
  */
-function GradebookGradeSummary($modal) {
-  this.$modal = $modal;
+function GradebookGradeSummary($content) {
+  this.$content = $content;
 
-  this.studentId = this.$modal.find("[data-studentid]").data("studentid");
+  this.studentId = this.$content.find("[data-studentid]").data("studentid");
 
   this.setupTabs();
   this.setupCategoryToggles();
   this.setupStudentNavigation();
+
+  this.$modal = this.$content.closest(".wicket-modal");
+
+  if (this.$modal.length > 0 && this.$modal.is(":visible")) {
+    this.setupFixedFooter();
+  } else {
+    setTimeout($.proxy(function() {
+      this.$modal = this.$content.closest(".wicket-modal");
+      this.setupFixedFooter();
+    }, this));
+  }
 };
 
 
 GradebookGradeSummary.prototype.setupTabs = function() {
-  this.$modal.find('#studentGradeSummaryTabs a').click(function (e) {
+  this.$content.find('#studentGradeSummaryTabs a').click(function (e) {
     e.preventDefault()
     $(this).tab('show')
   });
@@ -25,7 +36,7 @@ GradebookGradeSummary.prototype.setupTabs = function() {
 
 
 GradebookGradeSummary.prototype.setupCategoryToggles = function() {
-  this.$modal.find(".gb-summary-category-toggle").click(function() {
+  this.$content.find(".gb-summary-category-toggle").click(function() {
     var $toggle = $(this);
     if ($toggle.is(".collapsed")) {
       $toggle.closest("tbody").find(".gb-summary-grade-row").show();
@@ -35,19 +46,19 @@ GradebookGradeSummary.prototype.setupCategoryToggles = function() {
     $toggle.toggleClass("collapsed");
   });
 
-  this.$modal.find(".gb-summary-expand-all").click(function() {
+  this.$content.find(".gb-summary-expand-all").click(function() {
     $(".gb-summary-category-toggle.collapsed").trigger("click");
   });
-  this.$modal.find(".gb-summary-collapse-all").click(function() {
+  this.$content.find(".gb-summary-collapse-all").click(function() {
     $(".gb-summary-category-toggle:not(.collapsed)").trigger("click");
   });
 };
 
 
 GradebookGradeSummary.prototype.setupStudentNavigation = function() {
-  var $showPrevious = this.$modal.find(".gb-summary-previous-student");
-  var $showNext = this.$modal.find(".gb-summary-next-student");
-  var $done = this.$modal.find(".gb-summary-close");
+  var $showPrevious = this.$content.find(".gb-summary-previous-student");
+  var $showNext = this.$content.find(".gb-summary-next-student");
+  var $done = this.$content.find(".gb-summary-close");
 
   var $previous = sakai.gradebookng.spreadsheet.findVisibleStudentBefore(this.studentId);
   var $next = sakai.gradebookng.spreadsheet.findVisibleStudentAfter(this.studentId);
@@ -66,5 +77,16 @@ GradebookGradeSummary.prototype.setupStudentNavigation = function() {
     });    
   } else {
     $showNext.hide();
+  }
+};
+
+
+GradebookGradeSummary.prototype.setupFixedFooter = function() {
+  // do this by setting the height of the tab content to leave room for the navigation
+  if (this.$modal.height() > $(window).height()) {
+    var $tabPane = this.$content.find(".tab-content");
+    var paddingSize = 80; // modal padding and modal content padding/margins (yep... fudged)
+    var newHeight = $(window).height() - this.$content.offset().top - this.$content.find("h2").outerHeight() - this.$content.find(".nav").outerHeight() - this.$content.find(".gb-summary-modal-actions").outerHeight() - paddingSize;
+    $tabPane.height(Math.max(200, newHeight));
   }
 };

--- a/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -5,7 +5,7 @@
 /**************************************************************************************
  * A GradebookGradeSummary to encapsulate all the grade summary content behaviours 
  */
-function GradebookGradeSummary($content) {
+function GradebookGradeSummary($content, darkerMask) {
   this.$content = $content;
 
   this.studentId = this.$content.find("[data-studentid]").data("studentid");
@@ -18,6 +18,7 @@ function GradebookGradeSummary($content) {
 
   if (this.$modal.length > 0 && this.$modal.is(":visible")) {
     this.setupFixedFooter();
+    this.setupMask(darkerMask);
   } else {
     setTimeout($.proxy(function() {
       this.$modal = this.$content.closest(".wicket-modal");
@@ -88,5 +89,15 @@ GradebookGradeSummary.prototype.setupFixedFooter = function() {
     var paddingSize = 80; // modal padding and modal content padding/margins (yep... fudged)
     var newHeight = $(window).height() - this.$content.offset().top - this.$content.find("h2").outerHeight() - this.$content.find(".nav").outerHeight() - this.$content.find(".gb-summary-modal-actions").outerHeight() - paddingSize;
     $tabPane.height(Math.max(200, newHeight));
+  }
+};
+
+
+GradebookGradeSummary.prototype.setupMask = function(darkerMask) {
+  var $mask = this.$modal.siblings(".wicket-mask-transparent, .wicket-mask-dark");
+  if (darkerMask) {
+    $mask.removeClass("wicket-mask-transparent").addClass("wicket-mask-dark");
+  } else {
+    $mask.removeClass("wicket-mask-dark").addClass("wicket-mask-transparent");
   }
 };

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -824,6 +824,17 @@ ul.feedbackPanel li span {
   content: '\f061';
   padding-left: 4px;
 }
+.gb-grade-summary-content .tabpanel {
+  display: block;
+  margin-top: 10px;
+}
+.gb-grade-summary-content .tab-content {
+  overflow: auto;
+  margin: 10px 0;
+  padding: 10px 0;
+  border-top: 1px solid #DDD;
+  border-bottom: 1px solid #DDD;
+}
 /* Hidden column visual cue */
 .gb-hidden-column-visual-cue {
   position: absolute;

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -835,6 +835,9 @@ ul.feedbackPanel li span {
   border-top: 1px solid #DDD;
   border-bottom: 1px solid #DDD;
 }
+.gb-summary-grade-panel .gb-summary-grade-flags {
+  padding-left: 10px;
+}
 /* Hidden column visual cue */
 .gb-hidden-column-visual-cue {
   position: absolute;


### PR DESCRIPTION
As per minutes from the call:
- Get rid of item weights in weight column, but show the category weight
- Status icons should show up just to the right of the item
- Condense to 70% width
- Keep “Next Student/Previous Student” visible and scroll inside of it
- Pull Course Grade value closer to the label

~~TODO: normal lightbox treatment when in “Grade Summary,” Sexy Shower Glass, when in “Student Review Mode”.  I can do this in the Javascript, but let me know if you know of any Wicket tricks to get this working.  To help things out, I've refactored the tabs into an AjaxTabbedPanel.~~
I've had a go at changing the mask CSS class depending on the tab selected.  It's a mix between Wicket and custom JS, coz that's just how it all hit the fan. :boom:  I'll see if the "sexy shower glass" is feasible...
