### PR TITLE
Bring Student view into line with student grade summary

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -1,5 +1,6 @@
 package org.sakaiproject.gradebookng.business.util;
 
+import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -23,6 +24,18 @@ public class FormatHelper {
 
 		//TODO does the % need to be internationalised?
 		return df.format(score) + "%";
+	}
+
+
+	public static String formatStringAsPercentage(String string) {
+		if(StringUtils.isBlank(string)) {
+			return null;
+		}
+
+		BigDecimal decimal = new BigDecimal(string);
+		decimal.setScale(2, RoundingMode.HALF_DOWN); //same as GradebookService
+
+		return formatDoubleAsPercentage(decimal.doubleValue());
 	}
 
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.html
@@ -5,32 +5,20 @@
 <wicket:head>
   <wicket:link>
     <link rel="stylesheet" type="text/css" href="/gradebookng-tool/styles/gradebook-grades.css"/>
+    <script src="/gradebookng-tool/scripts/gradebook-grade-summary.js"></script>
   </wicket:link>
 </wicket:head>
 
 <wicket:extend>
   
 	<h2 wicket:id="heading">Grade Report for Tony Stark</h2>
-			
-	<h3><wicket:message key="label.studentsummary.coursegrade" /> <span wicket:id="courseGrade">B+</span></h3>
 
-	<table class="table table-striped table-bordered table-hover table-condensed">
-		<thead>
-			<tr>
-			   <th><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
-			   <th><wicket:message key="column.header.studentsummary.duedate" /></th>
-			   <th><wicket:message key="column.header.studentsummary.grade" /></th>
-			   <th><wicket:message key="column.header.studentsummary.weight" /></th>
-			   <th><wicket:message key="column.header.studentsummary.comments" /></th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr wicket:id="rows">
-			   <td wicket:id="dataRow"></td>
-			</tr>
-		</tbody>
-	</table>
-	
+	<div wicket:id="summary" id="studentGradeSummary"></div>
+
+	<script>
+		new GradebookGradeSummary($("#studentGradeSummary"));
+	</script>
+
 </wicket:extend>
 </body>
 </html>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
@@ -1,23 +1,13 @@
 package org.sakaiproject.gradebookng.tool.pages;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.repeater.Item;
-import org.apache.wicket.markup.repeater.RepeatingView;
-import org.apache.wicket.markup.repeater.data.DataView;
-import org.apache.wicket.markup.repeater.data.ListDataProvider;
-import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
-import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
-import org.sakaiproject.gradebookng.business.util.FormatHelper;
-import org.sakaiproject.service.gradebook.shared.Assignment;
-import org.sakaiproject.service.gradebook.shared.CourseGrade;
+import org.sakaiproject.gradebookng.tool.panels.StudentGradeSummaryGradesPanel;
 import org.sakaiproject.user.api.User;
 
 /**
@@ -33,86 +23,12 @@ public class StudentPage extends BasePage {
 			
 	public StudentPage() {
 
-		//get userId
 		User u = this.businessService.getCurrentUser();
-		
-        //get grades
-        final Map<Assignment, GbGradeInfo> grades = this.businessService.getGradesForStudent(u.getId());
-        
-        //get course grade
-        CourseGrade cg = this.businessService.getCourseGrade(u.getId());
-        
-		//assignment list
-        List<Assignment> assignments = new ArrayList<Assignment>(grades.keySet());
-		ListDataProvider<Assignment> listDataProvider = new ListDataProvider<Assignment>(assignments);
-        
-        DataView<Assignment> dataView = new DataView<Assignment>("rows", listDataProvider) {
 
-			private static final long serialVersionUID = 1L;
+		Map<String, Object> userData = new HashMap<>();
+		userData.put("userId", u.getId());
 
-			@Override 
-        	protected void populateItem(Item<Assignment> item) { 
-        		Assignment assignment = item.getModelObject(); 
-	    		RepeatingView repeatingView = new RepeatingView("dataRow");
-	
-	    		GbGradeInfo gradeInfo = grades.get(assignment.getId());
-	    		
-	    		//note, gradeInfo may be null
-	    		String rawGrade;
-	    		String comment;
-	    		if(gradeInfo != null) {
-	    			rawGrade = gradeInfo.getGrade();
-	    			comment = gradeInfo.getGradeComment();
-	    		} else {
-	    			rawGrade = "";
-	    			comment = "";
-	    		}
-	    		
-	    		repeatingView.add(new Label(repeatingView.newChildId(), assignment.getName()));
-	    		repeatingView.add(new Label(repeatingView.newChildId(), FormatHelper.formatDate(assignment.getDueDate(), getString("label.studentsummary.noduedate"))));
-	    		repeatingView.add(new Label(repeatingView.newChildId(), FormatHelper.formatGrade(rawGrade))); 
-	    		repeatingView.add(new Label(repeatingView.newChildId(), assignment.getWeight()));
-	    		repeatingView.add(new Label(repeatingView.newChildId(), comment)); 
-
-	    		item.add(repeatingView);
-    		} 
-        }; 
-        add(dataView);
-
-        //heading
-        add(new Label("heading", new StringResourceModel("heading.studentpage", null, new Object[]{ u.getDisplayName() })));
-	
-        //course grade
-        //if entered grade show only that grade (as the percentage value will be for the calculated grade)
-        //if mapped grade show both mapped grade and calculated percentage
-  
-        if(StringUtils.isBlank(cg.getEnteredGrade()) && StringUtils.isBlank(cg.getMappedGrade())) {
-        	add(new Label("courseGrade", new ResourceModel("label.studentsummary.coursegrade.none")));
-        } else if(StringUtils.isNotBlank(cg.getEnteredGrade())){
-        	add(new Label("courseGrade", cg.getEnteredGrade()));
-        } else {
-        	add(new Label("courseGrade", new StringResourceModel("label.studentsummary.coursegrade.display", null, new Object[] { cg.getMappedGrade(), formatPercentage(cg.getCalculatedGrade()) } )));
-        }
-           		
-	}	
-	
-	/**
-	 * Format a percentage to two decimal places
-	 * @param percentage
-	 * @return
-	 */
-	private String formatPercentage(String percentage) {
-		
-		if(StringUtils.isBlank(percentage)) {
-			return null;
-		}
-		
-		BigDecimal rval = new BigDecimal(percentage);
-		rval = rval.setScale(2, RoundingMode.HALF_DOWN); //same as GradebookService
-		return rval.toString() + "%";
-		
+		add(new Label("heading", new StringResourceModel("heading.studentpage", null, new Object[]{u.getDisplayName()})));
+		add(new StudentGradeSummaryGradesPanel("summary", Model.ofMap(userData)));
 	}
-	
-	
-	
 }

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
@@ -4,24 +4,26 @@
 <body>
 	<wicket:panel>
 		<div class="gb-summary-grade-panel">
-			<div class="row gb-summary-course-grade">
-				<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
-				<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span> <span wicket:id="courseGradeNotReleasedFlag"></span></div>
-			</div>
-	
-			<div class="row">
-				<div class="col-md-3">
-					<strong><wicket:message key="label.studentsummary.gradeitems" /></strong>
+			<div class="gb-summary-course-grade">
+				<div class="panel panel-default">
+					<div class="panel-body">
+						<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
+						<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span> <span wicket:id="courseGradeNotReleasedFlag">B+</span></div>
+					</div>
 				</div>
-				<div class="col-md-4">
+			</div>
+
+			<div class="col-md-12">
+				<div class="pull-right">
 					<a href="javascript:void(0);" class="gb-summary-expand-all"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
 					<a href="javascript:void(0);" class="gb-summary-collapse-all"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
 				</div>
 			</div>
+
 			<table class="table table-bordered table-striped table-hover table-condensed">
 				<thead>
 				<tr>
-					<th><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
+					<th class="col-md-5"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.duedate" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.grade" /></th>
 					<th><wicket:message key="column.header.studentsummary.comments" /></th>
@@ -55,8 +57,10 @@
 				</tr>
 				</tbody>
 			</table>
-			<p><small wicket:id="categoryScoreNotReleased"></small></p>
-			<p><small wicket:id="courseGradeNotReleasedMessage"></small></p>
+			<div class="col-md-12">
+				<p><small wicket:id="categoryScoreNotReleased"></small></p>
+				<p><small wicket:id="courseGradeNotReleasedMessage"></small></p>
+			</div>
 		</div>
 	</wicket:panel>
 </body>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
@@ -6,7 +6,7 @@
 		<div class="gb-summary-grade-panel">
 			<div class="row gb-summary-course-grade">
 				<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
-				<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span></div>
+				<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span> <span wicket:id="courseGradeNotReleasedFlag"></span></div>
 			</div>
 	
 			<div class="row">
@@ -40,6 +40,11 @@
 				<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
 					<td>
 						<span class="gb-summary-grade-title" wicket:id="title"></span>
+						<span class="gb-summary-grade-flags" wicket:id="flags">
+							<span wicket:id="isExtraCredit" class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracredit"></span>
+							<span wicket:id="isNotCounted" class="gb-flag-not-counted" wicket:message="title:label.gradeitem.notcounted"></span>
+							<span wicket:id="isNotReleased" class="gb-flag-not-released" wicket:message="title:label.gradeitem.notreleased"></span>
+						</span>
 					</td>
 					<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
 					<td class="gb-summary-grade-score">
@@ -51,6 +56,7 @@
 				</tbody>
 			</table>
 			<p><small wicket:id="categoryScoreNotReleased"></small></p>
+			<p><small wicket:id="courseGradeNotReleasedMessage"></small></p>
 		</div>
 	</wicket:panel>
 </body>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -4,24 +4,26 @@
 <body>
 	<wicket:panel>
 		<div class="gb-summary-grade-panel">
-			<div class="row gb-summary-course-grade">
-				<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
-				<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span></div>
-			</div>
-	
-			<div class="row">
-				<div class="col-md-3">
-					<strong><wicket:message key="label.studentsummary.gradeitems" /></strong>
+			<div class="gb-summary-course-grade">
+				<div class="panel panel-default">
+					<div class="panel-body">
+						<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
+						<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span></div>
+					</div>
 				</div>
-				<div class="col-md-4">
+			</div>
+
+			<div class="col-md-12">
+				<div class="pull-right">
 					<a href="javascript:void(0);" class="gb-summary-expand-all"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
 					<a href="javascript:void(0);" class="gb-summary-collapse-all"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
 				</div>
 			</div>
+
 			<table class="table table-bordered table-striped table-hover table-condensed">
 				<thead>
 				<tr>
-					<th><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
+					<th class="col-md-5"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.duedate" /></th>
 					<th class="col-md-1"><wicket:message key="column.header.studentsummary.grade" /></th>
 					<th><wicket:message key="column.header.studentsummary.comments" /></th>
@@ -50,7 +52,9 @@
 				</tr>
 				</tbody>
 			</table>
-			<p><small wicket:id="categoryScoreNotReleased"></small></p>
+			<div class="col-md-12">
+				<p><small wicket:id="categoryScoreNotReleased"></small></p>
+			</div>
 		</div>
 	</wicket:panel>
 </body>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.html
@@ -8,13 +8,15 @@
 
 			<span wicket:id="tabs" class="tabpanel">[tabbed panel will be here]</span>
 
-			<div class="gb-summary-modal-actions row">
-				<div wicket:id="studentNavigation" class="row">
+			<div class="gb-summary-modal-actions">
+				<div wicket:id="studentNavigation" class="col-md-12">
 					<a class="gb-summary-previous-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.previous" /></a>
 					<a class="gb-summary-next-student" href="javascript:void(0)"><wicket:message key="label.studentsummary.next" /></a>
 				</div>
 
-				<button type="submit" class="btn btn-secondary gb-summary-close" wicket:id="done"><wicket:message key="button.done" /></button>
+				<div class="col-md-12">
+					<button type="submit" class="btn btn-secondary gb-summary-close" wicket:id="done"><wicket:message key="button.done" /></button>
+				</div>
 			</div>
 		</div>
 	</wicket:panel>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
@@ -70,10 +70,10 @@ public class StudentGradeSummaryPanel extends Panel {
 		List tabs=new ArrayList();
 
 		tabs.add(new AbstractTab(new Model<String>(getString("label.studentsummary.instructorviewtab"))) {
-			public Panel getPanel(String panelId) { return new StudentGradeSummaryGradesPanel(panelId, (IModel<Map<String,Object>>) getDefaultModel(), StudentGradeSummaryGradesPanel.VIEW.INSTRUCTOR); }
+			public Panel getPanel(String panelId) { return new InstructorGradeSummaryGradesPanel(panelId, (IModel<Map<String,Object>>) getDefaultModel()); }
 		});
 		tabs.add(new AbstractTab(new Model<String>(getString("label.studentsummary.studentviewtab"))) {
-			public Panel getPanel(String panelId) { return new StudentGradeSummaryGradesPanel(panelId, (IModel<Map<String,Object>>) getDefaultModel(), StudentGradeSummaryGradesPanel.VIEW.STUDENT); }
+			public Panel getPanel(String panelId) { return new StudentGradeSummaryGradesPanel(panelId, (IModel<Map<String,Object>>) getDefaultModel()); }
 		});
 
 		add(new AjaxBootstrapTabbedPanel("tabs", tabs) {

--- a/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -10,18 +10,20 @@ function GradebookGradeSummary($content, darkerMask) {
 
   this.studentId = this.$content.find("[data-studentid]").data("studentid");
 
-  this.setupTabs();
   this.setupCategoryToggles();
-  this.setupStudentNavigation();
 
   this.$modal = this.$content.closest(".wicket-modal");
 
   if (this.$modal.length > 0 && this.$modal.is(":visible")) {
+    this.setupTabs();
+    this.setupStudentNavigation();
     this.setupFixedFooter();
     this.setupMask(darkerMask);
   } else {
     setTimeout($.proxy(function() {
       this.$modal = this.$content.closest(".wicket-modal");
+      this.setupTabs();
+      this.setupStudentNavigation();
       this.setupFixedFooter();
     }, this));
   }
@@ -86,7 +88,7 @@ GradebookGradeSummary.prototype.setupFixedFooter = function() {
   // do this by setting the height of the tab content to leave room for the navigation
   if (this.$modal.height() > $(window).height()) {
     var $tabPane = this.$content.find(".tab-content");
-    var paddingSize = 80; // modal padding and modal content padding/margins (yep... fudged)
+    var paddingSize = 150; // modal padding and modal content padding/margins (yep... fudged)
     var newHeight = $(window).height() - this.$content.offset().top - this.$content.find("h2").outerHeight() - this.$content.find(".nav").outerHeight() - this.$content.find(".gb-summary-modal-actions").outerHeight() - paddingSize;
     $tabPane.height(Math.max(200, newHeight));
   }

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -819,6 +819,7 @@ ul.feedbackPanel li span {
 .gb-summary-previous-student {
   float: left;
   padding-left: 20px;
+  margin-bottom: 10px;
 }
 .gb-summary-previous-student:before {
   font-family: 'gradebook-icons';
@@ -828,6 +829,7 @@ ul.feedbackPanel li span {
 .gb-summary-next-student {
   float: right;
   padding-right: 20px;
+  margin-bottom: 10px;
 }
 .gb-summary-next-student:after {
   font-family: 'gradebook-icons';
@@ -847,6 +849,9 @@ ul.feedbackPanel li span {
 }
 .gb-summary-grade-panel .gb-summary-grade-flags {
   padding-left: 10px;
+}
+#studentGradeSummary {
+  margin: 30px 0 0;
 }
 /* Hidden column visual cue */
 .gb-hidden-column-visual-cue {


### PR DESCRIPTION
Delivers #187.

I've refactored the existing summary panel.  Before it was sharing the one template for both the Instructor and Student, but given students have lesser access to data from the service I've refactored this into two panels - one for the instructor and one for the student.  The instructor panel behaves as before is able to call API endpoints that pull make more data.  The student panel uses endpoints that the student has permission to access. 

The consequence of changing the student panel API calls is that less data about categories are shown.  Currently the user needs permission to pull back the `CategoryDefinition`s for the gradebook. So the student misses out on the category score and category weight.  I'm guessing we'd need to extend/modify the gradebook service to deliver some of these extra values to students?

The last change was to then use this new student panel in the `StudentPage`.  That seems to be playing nice.

Thanks,
Payten
