### PR TITLE
IE only issue: fixes return opening modal instead of edit mode

### DIFF
--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -101,7 +101,7 @@ GradebookSpreadsheet.prototype.setupKeyboadNavigation = function() {
 
   self.$table.
     on("keydown", function(event) {
-      self.onKeydown(event);
+      return self.onKeydown(event);
     });
 };
 
@@ -136,6 +136,7 @@ GradebookSpreadsheet.prototype.onKeydown = function(event) {
 
   // return 13
   } else if (isEditableCell && event.keyCode == 13) {
+    event.preventDefault();
     self.getCellModel($eventTarget).enterEditMode(event.keyCode);
 
   // 0-9 48-57


### PR DESCRIPTION
Fix hitting return on a cell opening the Add Gradebook Item dialog instead of invoking the edit input of the cell (in IE only)
