### PR TITLE
Add validations and confirmation modal to "Set Scores" form

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -100,6 +100,11 @@ label.updateungradeditems.instructions.2 = <b>Note:</b> The value below will onl
 
 label.updateungradeditems.grade = Grade Override
 
+label.updateungradeditems.extracreditconfirmation.title=Extra Credit?
+label.updateungradeditems.extracreditconfirmation.content=The supplied score is in excess of the maximum point value for this Gradebook item. Do you want to continue?
+label.updateungradeditems.extracreditconfirmation.continue=Continue
+label.updateungradeditems.extracreditconfirmation.cancel=Cancel
+
 label.studentsummary.coursegrade = Course Grade:
 label.studentsummary.gradeitems = Gradebook Items
 label.studentsummary.outof = /{0}

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" type="text/css" href="/gradebookng-tool/styles/gradebook-grades.css"/>
     <script src="/gradebookng-tool/scripts/gradebook-grades.js"></script>
     <script src="/gradebookng-tool/scripts/gradebook-grade-summary.js"></script>
+    <script src="/gradebookng-tool/scripts/gradebook-update-ungraded.js"></script>
   </wicket:link>
 </wicket:head>
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -3,6 +3,7 @@ package org.sakaiproject.gradebookng.tool.panels;
 import java.lang.Exception;
 
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
@@ -254,10 +255,15 @@ public class AssignmentColumnHeaderPanel extends Panel {
 				
 				GradebookPage gradebookPage = (GradebookPage) this.getPage();
 				final ModalWindow window = gradebookPage.getUpdateUngradedItemsWindow();
-				
-				window.setContent(new UpdateUngradedItemsPanel(window.getContentId(), this.getModel(), window));
+
+				Component content = new UpdateUngradedItemsPanel(window.getContentId(), this.getModel(), window);
+
+				window.setContent(content);
 				window.showUnloadConfirmation(false);
 				window.show(target);
+
+				content.setOutputMarkupId(true);
+				target.appendJavaScript("new GradebookUpdateUngraded($(\"#"+content.getMarkupId()+"\"));");
 			}
 			
 			@Override

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
@@ -10,6 +10,8 @@
 				<wicket:message key="heading.updateungradeditems" />
 			</h2>
 
+			<div wicket:id="updateGradeFeedback"></div>
+
 			<div class="form-group">
 				
 				<div class="help-block">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
@@ -24,18 +24,40 @@
 						<wicket:message key="label.updateungradeditems.grade" />
 					</label>
 					<div class="col-xs-2">
-						<input wicket:id="grade" type="text" class="form-control" placeholder="100" />
+						<input wicket:id="grade" type="text" class="form-control gb-update-ungraded-value" placeholder="100" />
 					</div>
 				</div>
-				
+
 				<div class="col-xs-offset-4 col-xs-5">
-					<input type="submit" wicket:id="submit" wicket:message="value:button.update" />
-					<input type="submit" wicket:id="cancel" wicket:message="value:button.cancel" />
+					<button class="btn btn-primary gb-update-ungraded-fake-submit"><wicket:message key="button.done" /></button>
+					<input type="submit" class="hide gb-update-ungraded-real-submit" wicket:id="submit" wicket:message="value:button.update" />
+					<button class="btn btn-default" wicket:id="cancel"><wicket:message key="button.cancel"/></button>
 				</div>
 				
 			</div>
 
+			<input wicket:id="gradePoints" type="hidden" id="gradePoints"/>
 		</form>
+
+		<script id="extraCreditModalTemplate" type="text/template">
+			<div class="modal fade gb-update-ungraded-extracredit-confirmation">
+				<div class="modal-dialog">
+					<div class="modal-content">
+						<div class="modal-header">
+							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+							<h3 class="modal-title"><wicket:message key="label.updateungradeditems.extracreditconfirmation.title" /></h3>
+						</div>
+						<div class="modal-body">
+							<p><wicket:message key="label.updateungradeditems.extracreditconfirmation.content" /></p>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-primary gb-update-ungraded-extracredit-continue" data-dismiss="modal"><wicket:message key="label.updateungradeditems.extracreditconfirmation.continue" /></button>
+							<button type="button" class="btn btn-default gb-update-ungraded-extracredit-cancel" data-dismiss="modal"><wicket:message key="label.updateungradeditems.extracreditconfirmation.cancel" /></button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</script>
 	</wicket:panel>
 </body>
 </html>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
@@ -18,6 +18,7 @@ import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.extensions.markup.html.form.DateTextField;
 import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.CheckBox;
@@ -60,6 +61,8 @@ public class UpdateUngradedItemsPanel extends Panel {
 			
 	private static final double DEFAULT_GRADE = 0;
 
+	private boolean isExtraCreditValue = false;
+
 	public UpdateUngradedItemsPanel(String id, IModel<Long> model, ModalWindow window) {
 		super(id);
 		this.model = model;
@@ -76,7 +79,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 		GradeOverride override = new GradeOverride();
 		override.setGrade(DEFAULT_GRADE);
 		CompoundPropertyModel<GradeOverride> formModel = new CompoundPropertyModel<GradeOverride>(override);
-		
+
 		//build form
 		//modal window forms must be submitted via AJAX so we do not specify an onSubmit here
 		Form<GradeOverride> form = new Form<GradeOverride>("form", formModel);
@@ -88,6 +91,15 @@ public class UpdateUngradedItemsPanel extends Panel {
 				
 				GradeOverride override = (GradeOverride) form.getModelObject();
 
+				Assignment assignment = businessService.getAssignment(assignmentId);
+
+				if (override.getGrade() > assignment.getPoints()) {
+
+					target.addChildren(form, FeedbackPanel.class);
+				} else {
+					isExtraCreditValue = false;
+				}
+
 				boolean	success = businessService.updateUngradedItems(assignmentId, override.getGrade());
 
 				if(success) {
@@ -97,6 +109,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 					// InvalidGradeException
 					error(getString("grade.notifications.invalid"));
 					target.addChildren(form, FeedbackPanel.class);
+					target.appendJavaScript("new GradebookUpdateUngraded($(\"#"+getParent().getMarkupId()+"\"));");
 				}
 			}
 		};
@@ -139,6 +152,11 @@ public class UpdateUngradedItemsPanel extends Panel {
 		};
 		feedback.setOutputMarkupId(true);
 		form.add(feedback);
+
+		Assignment assignment = businessService.getAssignment(assignmentId);
+		WebMarkupContainer hiddenGradePoints = new WebMarkupContainer("gradePoints");
+		hiddenGradePoints.add(new AttributeModifier("value", assignment.getPoints()));
+		form.add(hiddenGradePoints);
 	}
 	
 	/**

--- a/tool/src/webapp/scripts/gradebook-update-ungraded.js
+++ b/tool/src/webapp/scripts/gradebook-update-ungraded.js
@@ -1,0 +1,50 @@
+/**************************************************************************************
+ *                    Gradebook Update Ungraded Javascript                                      
+ *************************************************************************************/
+
+/**************************************************************************************
+ * A GradebookUpdateUngraded to encapsulate all the update ungraded form behaviours 
+ */
+function GradebookUpdateUngraded($content) {
+  this.$content = $content;
+
+  this.setupExtraCreditCheck();
+};
+
+GradebookUpdateUngraded.prototype.setupExtraCreditCheck = function(){
+  var self = this;
+
+  function isExtraCreditValue() {
+    var gradePoints = parseFloat(self.$content.find("#gradePoints").val());
+    var updateValue = parseFloat(self.$content.find(".gb-update-ungraded-value").val());
+
+    return updateValue > gradePoints;
+  };
+
+  function showConfirmation() {
+      var $confirmationModal = $($("#extraCreditModalTemplate").html());
+      $confirmationModal.on("click", ".gb-update-ungraded-extracredit-continue", function() {
+        self.$content.find(".gb-update-ungraded-real-submit").trigger("click");
+      });
+      $(document.body).append($confirmationModal);
+      $confirmationModal.modal().modal('show');
+      $confirmationModal.on("hidden.bs.modal", function() {
+        $confirmationModal.remove();
+      });
+  };
+
+  function handleSubmit(event) {
+    if (isExtraCreditValue()) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      showConfirmation();
+
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  this.$content.find(".gb-update-ungraded-fake-submit").click(handleSubmit);
+};

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -909,7 +909,13 @@ ul.feedbackPanel li span {
   font-family: 'gradebook-icons';
   content: '\f04f';
 }
-/* Bootstrap > Morpheus overrides */
+/* Update Ungraded modal */
+.gb-update-ungraded-extracredit-confirmation {
+  z-index: 50000 !important;
+}
+.gb-update-ungraded-extracredit-confirmation .modal-dialog {
+  z-index: 50001 !important;
+}/* Bootstrap > Morpheus overrides */
 .dropdown-menu>li>a,
 .nav>li>a {
   text-decoration: none;


### PR DESCRIPTION
As per #177, this PR adds handling for a `InvalidGradeException` to the "Set Score for Empty Cells" form.

It also adds a confirmation to warn users when the value is greater than the grade item points.
