### PR TITLE
Additions to the "Add Gradebook Item" workflow

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -77,6 +77,7 @@ label.addgradeitem.due.help = Select a date
 label.addgradeitem.category = Category
 label.addgradeitem.release = Release this item to students?
 label.addgradeitem.include = Include this item in course grade calculations?
+label.addgradeitem.nocategories = No categories have been created
 error.addgradeitem.points = Points required and must be great than zero
 error.addgradeitem.title = Title required and must be unique
 error.addgradeitem.exception = Error creating Assignment

--- a/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -78,6 +78,7 @@ label.addgradeitem.category = Category
 label.addgradeitem.release = Release this item to students?
 label.addgradeitem.include = Include this item in course grade calculations?
 label.addgradeitem.nocategories = No categories have been created
+label.addgradeitem.categorywithweight = {0} ({1})
 error.addgradeitem.points = Points required and must be great than zero
 error.addgradeitem.title = Title required and must be unique
 error.addgradeitem.exception = Error creating Assignment

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -32,6 +32,8 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.string.StringValue;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.model.GbGroup;
@@ -60,6 +62,7 @@ public class GradebookPage extends BasePage {
 	private static final long serialVersionUID = 1L;
 
 	public static final String UNCATEGORIZED = "Uncategorized";
+	public static final String CREATED_ASSIGNMENT_ID_PARAM = "createdAssignmentId";
 
 	ModalWindow addGradeItemWindow;
 	ModalWindow studentGradeSummaryWindow;
@@ -257,6 +260,13 @@ public class GradebookPage extends BasePage {
             		
             		panel.add(new AttributeModifier("data-category", category));
             		panel.add(new AttributeModifier("data-categorized-order", order));
+
+            		StringValue createdAssignmentId = getPageParameters().get(CREATED_ASSIGNMENT_ID_PARAM);
+            		if (!createdAssignmentId.isNull() && assignment.getId().equals(createdAssignmentId.toLong())) {
+            			panel.add(new AttributeModifier("class", "gb-just-created"));
+            			getPageParameters().remove(CREATED_ASSIGNMENT_ID_PARAM);
+            		}
+
     				return panel;
             	}
 

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanel.java
@@ -11,8 +11,10 @@ import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
 import org.sakaiproject.service.gradebook.shared.ConflictingAssignmentNameException;
@@ -48,9 +50,11 @@ public class AddGradeItemPanel extends Panel {
 			public void onSubmit(AjaxRequestTarget target, Form form) {
 				Assignment assignment =  (Assignment) form.getModelObject();
 
+				Long assignmentId = null;
+
 				boolean success = true;
 				try {
-					businessService.addAssignment(assignment);
+					assignmentId = businessService.addAssignment(assignment);
 				} catch (AssignmentHasIllegalPointsException e) {
 					error(new ResourceModel("error.addgradeitem.points").getObject());
 					success = false;
@@ -66,7 +70,7 @@ public class AddGradeItemPanel extends Panel {
 				}
 				if (success) {
 					getSession().info(MessageFormat.format(getString("notification.addgradeitem.success"), assignment.getName()));
-					setResponsePage(getPage().getPageClass());
+					setResponsePage(getPage().getPageClass(), new PageParameters().add(GradebookPage.CREATED_ASSIGNMENT_ID_PARAM, assignmentId));
 				} else {
 					target.addChildren(form, FeedbackPanel.class);
 				}

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.html
@@ -80,6 +80,7 @@
 					<select wicket:id="category" class="form-control">
 						<option>test</option>
 					</select>
+					<span wicket:id="noCategoriesMessage" class="help-block"><wicket:message key="label.addgradeitem.nocategories"></wicket:message></span>
 				</div>
 			</div>
 			<div class="form-group form-group-sm">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
@@ -11,11 +11,16 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.business.util.FormatHelper;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
+import org.sakaiproject.service.gradebook.shared.GradebookService;
+import org.sakaiproject.tool.gradebook.Gradebook;
 
+import java.text.MessageFormat;
 import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
@@ -37,22 +42,30 @@ public class AddGradeItemPanelContent extends Panel {
     public AddGradeItemPanelContent(String id, Model<Assignment> assignment) {
         super(id, assignment);
 
+        final Gradebook gradebook = businessService.getGradebook();
+
         add(new TextField<String>("title", new PropertyModel<String>(assignment, "name")));
         add(new TextField<Double>("points", new PropertyModel<Double>(assignment, "points")));
         add(new DateTextField("duedate", new PropertyModel<Date>(assignment, "dueDate"), "MM/dd/yyyy")); //TODO needs to come from i18n
 
         final List<CategoryDefinition> categories = businessService.getGradebookCategories();
 
-        final Map<Long, String> categoryMap = new HashMap<>();
+        final Map<Long, CategoryDefinition> categoryMap = new HashMap<>();
         for (CategoryDefinition category : categories) {
-            categoryMap.put(category.getId(), category.getName());
+            categoryMap.put(category.getId(), category);
         }
 
         DropDownChoice<Long> categoryDropDown = new DropDownChoice<Long>("category", new PropertyModel<Long>(assignment, "categoryId"), new ArrayList<Long>(categoryMap.keySet()), new IChoiceRenderer<Long>() {
 			private static final long serialVersionUID = 1L;
 
 			public Object getDisplayValue(Long value) {
-                return categoryMap.get(value);
+                CategoryDefinition category = categoryMap.get(value);
+                if (GradebookService.CATEGORY_TYPE_WEIGHTED_CATEGORY == gradebook.getCategory_type()) {
+                    String weight = FormatHelper.formatDoubleAsPercentage(category.getWeight() * 100);
+                    return MessageFormat.format(getString("label.addgradeitem.categorywithweight"), category.getName(), weight);
+                } else {
+                    return category.getName();
+                }
             }
 
             public String getIdValue(Long object, int index) {

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
@@ -3,6 +3,7 @@ package org.sakaiproject.gradebookng.tool.panels;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
 import org.apache.wicket.extensions.markup.html.form.DateTextField;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
@@ -40,7 +41,7 @@ public class AddGradeItemPanelContent extends Panel {
         add(new TextField<Double>("points", new PropertyModel<Double>(assignment, "points")));
         add(new DateTextField("duedate", new PropertyModel<Date>(assignment, "dueDate"), "MM/dd/yyyy")); //TODO needs to come from i18n
 
-        List<CategoryDefinition> categories = businessService.getGradebookCategories();
+        final List<CategoryDefinition> categories = businessService.getGradebookCategories();
 
         final Map<Long, String> categoryMap = new HashMap<>();
         for (CategoryDefinition category : categories) {
@@ -57,9 +58,18 @@ public class AddGradeItemPanelContent extends Panel {
             public String getIdValue(Long object, int index) {
                 return object.toString();
             }
+
         });
         categoryDropDown.setNullValid(true);
+        categoryDropDown.setVisible(!categories.isEmpty());
         add(categoryDropDown);
+
+        add(new WebMarkupContainer("noCategoriesMessage") {
+            @Override
+            public boolean isVisible() {
+                return categories.isEmpty();
+            }
+        });
 
         add(new CheckBox("extraCredit", new PropertyModel<Boolean>(assignment, "extraCredit")));
        

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -35,6 +35,8 @@ function GradebookSpreadsheet($spreadsheet) {
   this.setupColoredCategories();
   this.setupPopovers();
 
+  this.setupNewAssignmentFocus();
+
   this.ready();
 };
 
@@ -1297,6 +1299,18 @@ GradebookSpreadsheet.prototype.findVisibleStudentAfter = function(studentUuid) {
   }
 }
 
+
+GradebookSpreadsheet.prototype.setupNewAssignmentFocus = function() {
+  var self = this;
+
+  var $justCreated = self.$table.find(".gb-just-created");
+
+  if ($justCreated.length > 0) {
+    self.onReady(function() {
+      $justCreated.parent().focus();
+    });
+  }
+};
 
 
 /*************************************************************************************


### PR DESCRIPTION
Delivers #176.

Namely, this PR adds:
- a note when there are no categories (instead of an empty dropdown list)
- the category weight to the dropdown list labels if weights are enabled
- focuses the newly created grade item after the POST refreshes the page

Looking at the current behaviour, the newly added grade items seem to be added to the rightmost position (when categorised or not), so didn't make any changes to that code.
