### PR TITLE
Set Ungraded fixes

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
@@ -40,7 +40,7 @@
 		</form>
 
 		<script id="extraCreditModalTemplate" type="text/template">
-			<div class="modal fade gb-update-ungraded-extracredit-confirmation">
+			<div class="modal gb-update-ungraded-extracredit-confirmation">
 				<div class="modal-dialog">
 					<div class="modal-content">
 						<div class="modal-header">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
@@ -77,7 +77,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 		
 		//form model
 		GradeOverride override = new GradeOverride();
-		override.setGrade(DEFAULT_GRADE);
+		override.setGrade(String.valueOf(DEFAULT_GRADE));
 		CompoundPropertyModel<GradeOverride> formModel = new CompoundPropertyModel<GradeOverride>(override);
 
 		//build form
@@ -93,19 +93,28 @@ public class UpdateUngradedItemsPanel extends Panel {
 
 				Assignment assignment = businessService.getAssignment(assignmentId);
 
-				if (override.getGrade() > assignment.getPoints()) {
+				try {
+					Double overrideValue = Double.valueOf(override.getGrade());
 
-					target.addChildren(form, FeedbackPanel.class);
-				} else {
-					isExtraCreditValue = false;
-				}
+					if (overrideValue > assignment.getPoints()) {
 
-				boolean	success = businessService.updateUngradedItems(assignmentId, override.getGrade());
+						target.addChildren(form, FeedbackPanel.class);
+					} else {
+						isExtraCreditValue = false;
+					}
 
-				if(success) {
-					window.close(target);
-					setResponsePage(new GradebookPage());
-				} else {
+					boolean	success = businessService.updateUngradedItems(assignmentId, overrideValue);
+
+					if(success) {
+						window.close(target);
+						setResponsePage(new GradebookPage());
+					} else {
+						// InvalidGradeException
+						error(getString("grade.notifications.invalid"));
+						target.addChildren(form, FeedbackPanel.class);
+						target.appendJavaScript("new GradebookUpdateUngraded($(\"#"+getParent().getMarkupId()+"\"));");
+					}
+				} catch (NumberFormatException e) {
 					// InvalidGradeException
 					error(getString("grade.notifications.invalid"));
 					target.addChildren(form, FeedbackPanel.class);
@@ -168,7 +177,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 		
 		@Getter
 		@Setter
-		private double grade;
+		private String grade;
 		
 	}
 	

--- a/tool/src/webapp/scripts/gradebook-update-ungraded.js
+++ b/tool/src/webapp/scripts/gradebook-update-ungraded.js
@@ -24,27 +24,39 @@ GradebookUpdateUngraded.prototype.setupExtraCreditCheck = function(){
   function showConfirmation() {
       var $confirmationModal = $($("#extraCreditModalTemplate").html());
       $confirmationModal.on("click", ".gb-update-ungraded-extracredit-continue", function() {
-        self.$content.find(".gb-update-ungraded-real-submit").trigger("click");
+        performRealSubmit();
       });
       $(document.body).append($confirmationModal);
-      $confirmationModal.modal().modal('show');
+
       $confirmationModal.on("hidden.bs.modal", function() {
         $confirmationModal.remove();
       });
+      $confirmationModal.on("show.bs.modal", function() {
+        var $formModal = self.$content.closest(".wicket-modal");
+        $confirmationModal.css("marginTop", $formModal.offset().top + 40);
+      });
+
+      $confirmationModal.modal().modal('show');
   };
 
-  function handleSubmit(event) {
+
+  function performRealSubmit() {
+    self.$content.find(".gb-update-ungraded-real-submit").trigger("click");
+  };
+
+
+  function handleFakeSubmit(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
     if (isExtraCreditValue()) {
-      event.preventDefault();
-      event.stopPropagation();
-
       showConfirmation();
-
-      return false;
     } else {
-      return true;
+      performRealSubmit();
     }
+
+    return false;
   };
 
-  this.$content.find(".gb-update-ungraded-fake-submit").click(handleSubmit);
+  this.$content.find(".gb-update-ungraded-fake-submit").off("click").on("click", handleFakeSubmit);
 };

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -910,6 +910,13 @@ ul.feedbackPanel li span {
   content: '\f04f';
 }
 /* Update Ungraded modal */
+.gb-update-ungraded-extracredit-confirmation.in  
+  position: absolute;
+  right:0;
+  bottom: auto;
+  left: 0;
+  overflow: auto;
+}
 .gb-update-ungraded-extracredit-confirmation {
   z-index: 50000 !important;
 }


### PR DESCRIPTION
Delivers #177.
- Fix set ungraded form not submitting values at all (caused by js override).
- Also ensure error message displays for invalid values both non-double and negatives. 
- And also force the extra credit confirmation modal to display above the position of the ungraded form modal wherever it is positioned on the page.
