### PR TITLE
Allow a null score (or empty string) to be a valid score

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -452,16 +452,18 @@ public class GradebookNgBusinessService {
 		
 		//about to edit so push a notification
 		pushEditingNotification(gradebook.getUid(), this.getCurrentUser(), studentUuid, assignmentId);
-		
-		Double newGradePoints = NumberUtils.toDouble(newGrade);
-		
+
 		GradeSaveResponse rval = null;
-		
-		if(newGradePoints.compareTo(maxPoints) > 0) {
-			log.debug("over limit. Max: " + maxPoints);
-			rval = GradeSaveResponse.OVER_LIMIT;
+
+		if (StringUtils.isNotBlank(newGrade)) {
+			Double newGradePoints = NumberUtils.toDouble(newGrade);
+
+			if(newGradePoints.compareTo(maxPoints) > 0) {
+				log.debug("over limit. Max: " + maxPoints);
+				rval = GradeSaveResponse.OVER_LIMIT;
+			}
 		}
-		
+
 		//save
 		try {
 			//note, you must pass in the comment or it wil lbe nulled out by the GB service

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -158,7 +158,7 @@ public class GradeItemCellPanel extends Panel {
 					//perform validation here so we can bypass the backend
 					DoubleValidator validator = new DoubleValidator();
 					
-					if(!validator.isValid(newGrade)) {
+					if(StringUtils.isNotBlank(newGrade) && !validator.isValid(newGrade)) {
 						markWarning(this);
 						this.getLabel().setDefaultModelObject(this.originalGrade);
 					} else {


### PR DESCRIPTION
… that can be set by removing the value from the cell.

Delivers #218.

As mentioned on the call, this PR could use a quick once over.  It's a fairly simple change to allow an empty string to be a valid value: `if(StringUtils.isNotBlank(newGrade) && !validator.isValid(newGrade)) {...}` which allows the empty string to be sent to the gradebookService.. it didn't complain!
