### PR TITLE
Student drilldown stuff take 4

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
@@ -7,8 +7,8 @@
 			<div class="gb-summary-course-grade">
 				<div class="panel panel-default">
 					<div class="panel-body">
-						<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
-						<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span> <span wicket:id="courseGradeNotReleasedFlag">B+</span></div>
+						<div class="gb-summary-course-grade-label col-md-3"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
+						<div class="gb-summary-course-grade-value col-md-9"><span wicket:id="courseGrade">B+</span> <span wicket:id="courseGradeNotReleasedFlag">B+</span></div>
 					</div>
 				</div>
 			</div>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
@@ -1,5 +1,6 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -160,7 +161,7 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 						assignmentItem.add(new Label("outOf",  new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {
 							@Override
 							public boolean isVisible() {
-								return rawGrade != "";
+								return StringUtils.isNotBlank(rawGrade);
 							}
 						});
 						assignmentItem.add(new Label("comments", comment));

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -7,8 +7,8 @@
 			<div class="gb-summary-course-grade">
 				<div class="panel panel-default">
 					<div class="panel-body">
-						<div class="gb-summary-course-grade-label col-md-2"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
-						<div class="gb-summary-course-grade-value col-md-10"><span wicket:id="courseGrade">B+</span></div>
+						<div class="gb-summary-course-grade-label col-md-3"><strong><wicket:message key="label.studentsummary.coursegrade" /></strong></div>
+						<div class="gb-summary-course-grade-value col-md-9"><span wicket:id="courseGrade">B+</span></div>
 					</div>
 				</div>
 			</div>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -43,6 +43,10 @@
 				<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
 					<td>
 						<span class="gb-summary-grade-title" wicket:id="title"></span>
+						<span class="gb-summary-grade-flags" wicket:id="flags">
+							<span wicket:id="isExtraCredit" class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracredit"></span>
+							<span wicket:id="isNotCounted" class="gb-flag-not-counted" wicket:message="title:label.gradeitem.notcounted"></span>
+						</span>
 					</td>
 					<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
 					<td class="gb-summary-grade-score">

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -139,6 +139,22 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 						Label title = new Label("title", assignment.getName());
 						assignmentItem.add(title);
 
+						WebMarkupContainer flags = new WebMarkupContainer("flags");
+						flags.add(new WebMarkupContainer("isExtraCredit") {
+							@Override
+							public boolean isVisible() {
+								return assignment.getExtraCredit();
+							}
+						});
+						flags.add(new WebMarkupContainer("isNotCounted") {
+							@Override
+							public boolean isVisible() {
+								return !assignment.isCounted();
+							}
+						});
+						assignmentItem.add(flags);
+
+
 						assignmentItem.add(new Label("dueDate", FormatHelper.formatDate(assignment.getDueDate(), getString("label.studentsummary.noduedate"))));
 						assignmentItem.add(new Label("grade", FormatHelper.formatGrade(rawGrade)));
 						assignmentItem.add(new Label("outOf",  new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -144,7 +144,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 						assignmentItem.add(new Label("outOf",  new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {
 							@Override
 							public boolean isVisible() {
-								return rawGrade != "";
+								return StringUtils.isNotBlank(rawGrade);
 							}
 						});
 						assignmentItem.add(new Label("comments", comment));

--- a/tool/src/webapp/styles/gradebook-grades.css
+++ b/tool/src/webapp/styles/gradebook-grades.css
@@ -815,6 +815,9 @@ ul.feedbackPanel li span {
   margin-top: 20px;
   padding-top: 20px;
 }
+.gb-summary-grade-score-outof {
+  color: #999;
+}
 .gb-summary-grade-panel .gb-summary-category-row td:first-child {
   font-weight: bold;
 }


### PR DESCRIPTION
Delivers #187. Namely:
- Don't show out-of suffix if score is empty
- Soften out-of suffix so score stands out
- Increase width of course grade label to avoid wrapping
- Added extra-credit and included-in-course-grade-calculation flags in student view

Still TODO: category score on student view.
