### PR TITLE
Fix sort not applying for column if a sort already applies

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -66,7 +66,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 				GradebookUiSettings settings = gradebookPage.getUiSettings();
 				
 				//if null, set a default sort, otherwise toggle, save, refresh.
-				if(settings.getAssignmentSortOrder() == null) {
+				if(settings.getAssignmentSortOrder() == null || !assignment.getId().equals(settings.getAssignmentSortOrder().getAssignmentId())) {
 					settings.setAssignmentSortOrder(new GbAssignmentGradeSortOrder(assignment.getId(), SortDirection.ASCENDING));
 				} else {
 					GbAssignmentGradeSortOrder sortOrder = settings.getAssignmentSortOrder();


### PR DESCRIPTION
This patch ensures a GbAssignmentGradeSortOrder is properly set up for the last-clicked item.

Delivers #219.
