### PR TITLE
Ensure "Release item to students" checkbox is disabled when "counted" is checked

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddGradeItemPanelContent.java
@@ -104,6 +104,7 @@ public class AddGradeItemPanelContent extends Panel {
 			}
         };
         released.setOutputMarkupId(true);
+        released.setEnabled(!assignment.getObject().isCounted());
         add(released);
         
         //if checked, release must also be checked and then disabled


### PR DESCRIPTION
… on the gradebook item edit form.

Delivers #230.
