### PR TITLE
Dynamic course grade and category averages

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -367,6 +367,8 @@ public class GradebookPage extends BasePage {
             		
             		Map<String,Object> modelData = new HashMap<>();
     				modelData.put("score", score);
+    				modelData.put("studentUuid", studentGrades.getStudentUuid());
+    				modelData.put("categoryId", category.getId());
     				
     				cellItem.add(new CategoryColumnCellPanel(componentId, Model.ofMap(modelData)));
     				cellItem.setOutputMarkupId(true);

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnCellPanel.html
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnCellPanel.html
@@ -4,7 +4,7 @@
 <body>
 <wicket:panel>
 	
-	<wicket:container wicket:id="score">score</wicket:container>
+	<span wicket:id="score">score</span>
 		
 </wicket:panel>
 </body>

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -16,6 +16,7 @@ import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.core.util.string.ComponentRenderer;
+import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxEditableLabel;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -29,6 +30,7 @@ import org.sakaiproject.gradebookng.business.GradeSaveResponse;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.model.ScoreChangedEvent;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 
 /**
@@ -88,6 +90,7 @@ public class GradeItemCellPanel extends Panel {
 		final Long assignmentId = (Long) modelData.get("assignmentId");
 		final Double assignmentPoints = (Double) modelData.get("assignmentPoints");
 		final String studentUuid = (String) modelData.get("studentUuid");
+		final Long categoryId = (Long) modelData.get("categoryId");
 		final boolean isExternal = (boolean) modelData.get("isExternal");
 		final GbGradeInfo gradeInfo = (GbGradeInfo) modelData.get("gradeInfo");
 		
@@ -196,6 +199,7 @@ public class GradeItemCellPanel extends Panel {
 					}
 
 					//refresh the components we need
+					send(getPage(), Broadcast.BREADTH, new ScoreChangedEvent(studentUuid, categoryId, target));
 					target.addChildren(getPage(), FeedbackPanel.class);
 					target.add(getParentCellFor(this));
 					target.add(this);

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1324,6 +1324,20 @@ GradebookSpreadsheet.prototype.setupNewAssignmentFocus = function() {
 };
 
 
+GradebookSpreadsheet.prototype.refreshCourseGradeForStudent = function(studentUuid) {
+  // cell has been updated, so need to refresh the course grade in the fixed column
+  // on the off chance the grade has changed
+  var $studentNameCell = this.$table.find(".gb-student-cell[data-studentuuid='"+studentUuid+"']");
+  var $courseGradeCell = $studentNameCell.closest("tr").find(".gb-course-grade.gb-cell");
+
+  var $fixedColumnStudentNameCell = this.$fixedColumns.find(".gb-student-cell[data-studentuuid='"+studentUuid+"']");
+  var $fixedColumnCourseGradeCell = $fixedColumnStudentNameCell.closest("tr").find(".gb-course-grade.gb-cell");
+
+  var courseGrade = this._cloneCell($courseGradeCell).html();
+  $fixedColumnCourseGradeCell.html(courseGrade);
+};
+
+
 /*************************************************************************************
  * AbstractCell - behaviour inherited by all cells
  */
@@ -1516,6 +1530,9 @@ GradebookEditableCell.prototype.handleSaveComplete = function(cellId) {
   if (this.$cell.is('[data-toggle="popover"]')) {
     this.gradebookSpreadsheet.enablePopovers(this.$cell);
   }
+
+  //refresh the course grade
+  this.gradebookSpreadsheet.refreshCourseGradeForStudent(this.$cell.data("studentuuid"));
 
   if (this._focusAfterSaveComplete) {
     this.$cell.focus();


### PR DESCRIPTION
I've had a go at delivering #239 - dynamic course grade and category columns.

This PR relies on PR #245 for the course grade cell refactor.

I've introduced a page scoped event `ScoreChangedEvent` which is broadcast upon a score changing.  The course grade and category average labels listen for this event and refresh their values upon receiving an event for their `studentUuid` and/or `categoryId`. 

I have a feeling this solution adds those service calls to the critical path of the input switching back to a label.  But given the async nature of editing, perhaps that won't be too annoying for the user.  Let me know what you think @steveswinsburg.
