### PR TITLE
Add category averages to the student view of the grade drilldown

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1485,7 +1485,7 @@ public class GradebookNgBusinessService {
     	 String siteId = this.getCurrentSiteId();
     	     	 
     	 //get assignments (filtered to just the category ones later)
-    	 List<Assignment> assignments = this.getGradebookAssignments(siteId);
+    	 List<Assignment> assignments = new ArrayList<Assignment>(grades.keySet());
     	 
     	 //build map of just the grades and assignments we want for the assignments in the given category
     	 Map<Long,String> gradeMap = new HashMap<>();
@@ -1494,7 +1494,7 @@ public class GradebookNgBusinessService {
     	 while (iter.hasNext()) {
     		 Assignment assignment = iter.next();
     		 if(categoryId == assignment.getCategoryId()) {
-    			 GbGradeInfo gradeInfo = grades.get(assignment.getId());
+    			 GbGradeInfo gradeInfo = grades.get(assignment);
     			 if(gradeInfo != null) {
     				 gradeMap.put(assignment.getId(),gradeInfo.getGrade());
     			 }

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -54,6 +54,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		
 		final List<String> categoryNames = new ArrayList<String>();
 		final Map<String, List<Assignment>> categoriesToAssignments = new HashMap<String, List<Assignment>>();
+		final Map<String, String> categoryAverages = new HashMap<>();
 
 		Iterator<Assignment> assignmentIterator = assignments.iterator();
 		while (assignmentIterator.hasNext()) {
@@ -63,6 +64,13 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 			if (!categoriesToAssignments.containsKey(category)) {
 				categoryNames.add(category);
 				categoriesToAssignments.put(category, new ArrayList<Assignment>());
+
+				Double categoryAverage = businessService.getCategoryScoreForStudent(assignment.getCategoryId(), userId, grades);
+				if (categoryAverage == null || category.equals(GradebookPage.UNCATEGORIZED)) {
+					categoryAverages.put(category, getString("label.nocategoryscore"));
+				} else {
+					categoryAverages.put(category, FormatHelper.formatDoubleAsPercentage(categoryAverage));
+				}
 			}
 
 			categoriesToAssignments.get(category).add(assignment);
@@ -92,13 +100,8 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 				}
 
 				if (allAssignmentsAreReleased) {
-					// TODO can a student access category averages?
-					Double score = null;//gradeInfo.getCategoryAverages().get(categoryDefinition.getId());
-					String grade = "";
-					if (score != null) {
-						grade = FormatHelper.formatDoubleAsPercentage(score);
-					}
-					categoryItem.add(new Label("categoryGrade", grade));
+					String categoryAverage = categoryAverages.get(category);
+					categoryItem.add(new Label("categoryGrade", categoryAverage));
 				} else {
 					categoryScoreHidden[0] = true;
 					categoryItem.add(new Label("categoryGrade", getString("label.studentsummary.categoryscoreifhiddenassignment")));


### PR DESCRIPTION
Delivers #202, #187.

Thanks @steveswinsburg.  I've used the new business service endpoint to grab the category averages.  I had to tweak to the `grades` look up a little - instead of pulling back the assignments from the service I use `grades.keySet()` as the `assignment` is the hash key.  Hopefully that's ok? 
