### PR TITLE
Ensure the cell is updated when a comment is removed as well as when added

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -335,11 +335,11 @@ public class GradeItemCellPanel extends Panel {
 						
 						if(StringUtils.isNotBlank(comment)) {
 							markHasComment(gradeCell);
-							target.add(getParentCellFor(gradeCell));
-							target.appendJavaScript("sakai.gradebookng.spreadsheet.setupCell('" + getParentCellFor(gradeCell).getMarkupId() + "','" + assignmentId + "', '" + studentUuid + "');");
-							refreshNotifications();
 						};
 						
+						target.add(getParentCellFor(gradeCell));
+						target.appendJavaScript("sakai.gradebookng.spreadsheet.setupCell('" + getParentCellFor(gradeCell).getMarkupId() + "','" + assignmentId + "', '" + studentUuid + "');");
+						refreshNotifications();
 					}
 				});
 				window.show(target);


### PR DESCRIPTION
Delivers bug "Comment bubble is retained after deleting comment contents - need to refresh tool to make it disappear." as reported in the 10/1/2015 team call.
