### PR TITLE
Fix “Hide this category” shows up in category dropdown menu after “Hide All” is selected in Show/Hide Items

### DIFF
--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1916,12 +1916,12 @@ GradebookToolbar.prototype.setupToggleGradeItems = function() {
 
 
   function handleShowAll() {
-    self.$gradeItemsFilterPanel.find(".gradebook-item-filter :input:not(:checked), .gradebook-item-category-score-filter :input:not(:checked)").trigger("click");
+    self.$gradeItemsFilterPanel.find(".gradebook-item-category-filter :input:not(:checked)").trigger("click");
   };
 
 
   function handleHideAll() {
-    self.$gradeItemsFilterPanel.find(".gradebook-item-filter :input:checked, .gradebook-item-category-score-filter :input:checked").trigger("click");
+    self.$gradeItemsFilterPanel.find(".gradebook-item-category-filter :input:checked").trigger("click");
   };
 
 


### PR DESCRIPTION
Raised in the 10/1/2015 team call.

Only trigger clicks on the category checkboxes when a user selects Hide All or Show All. This will ensure each checkbox that needs clicking will only be triggered once and therefore the states of the filter item's menu are kept nicely in sync
