### PR TITLE
Group by category enhancements

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -491,6 +491,7 @@ public class GradebookPage extends BasePage {
 		
 		if(settings == null) {
 			settings = new GradebookUiSettings();
+			settings.setCategoriesEnabled(businessService.categoriesAreEnabled());
 		}
 		
 		return settings;

--- a/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -395,6 +395,10 @@ public class GradebookPage extends BasePage {
                 target.add(this);
                 target.appendJavaScript("sakai.gradebookng.spreadsheet.toggleCategories();");
             }
+            @Override
+            public boolean isVisible() {
+                return businessService.categoriesAreEnabled();
+            }
         };
         form.add(toggleCategoriesToolbarItem);
 

--- a/tool/src/webapp/scripts/gradebook-grades.js
+++ b/tool/src/webapp/scripts/gradebook-grades.js
@@ -1994,16 +1994,29 @@ GradebookToolbar.prototype.setupToggleGradeItems = function() {
   self.$toolbar.on("click", "#toggleGradeItemsToolbarItem", function(event) {
     event.preventDefault();
 
-    $(this).toggleClass("on");
+    var $button = $(this);
 
-    if ($(this).hasClass("on")) {
+    $button.toggleClass("on");
+
+    if ($button.hasClass("on")) {
       repositionPanel();
-      $(this).attr("aria-expanded", "true");
+      $button.attr("aria-expanded", "true");
       self.$gradeItemsFilterPanel.show().attr("aria-hidden", "false");
     } else {
-      $(this).attr("aria-expanded", "false");
+      $button.attr("aria-expanded", "false");
       self.$gradeItemsFilterPanel.hide().attr("aria-hidden", "true");
     }
+
+    // Support click outside menu panel to close panel
+    function hidePanelOnOuterClick(mouseDownEvent) {
+      if ($(mouseDownEvent.target).closest(".gb-toggle-grade-items-panel, #toggleGradeItemsToolbarItem").length == 0) {
+        $button.removeClass("on");
+        $button.attr("aria-expanded", "false");
+        self.$gradeItemsFilterPanel.hide().attr("aria-hidden", "true");
+        $(document).off("mousedown", hidePanelOnOuterClick);
+      }
+    };
+    $(document).on("mousedown", hidePanelOnOuterClick);
 
     return false;
   });


### PR DESCRIPTION
Delivers:
#257 - hide the Group by Categories button if categories are not enabled
#258 - allow the Show/Hide Items panel to be hidden by a mouse click outside of the panel
#260 - the simple solution for this issue minus any storage changes! We now default the Group by Category setting to 'true' if categories are enabled for the Gradebook.  If this toggled off, refreshing the page will retain this setting as it is stored on the session; if the tool is reset it will revert to true.
