### PR TITLE
#281 Refresh the course grade and category average off the critical path

### DIFF
--- a/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.validator.routines.DoubleValidator;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
@@ -215,10 +216,12 @@ public class GradeItemCellPanel extends Panel {
 					}
 
 					//refresh the components we need
-					send(getPage(), Broadcast.BREADTH, new ScoreChangedEvent(studentUuid, categoryId, target));
 					target.addChildren(getPage(), FeedbackPanel.class);
 					target.add(getParentCellFor(this));
 					target.add(this);
+
+					//trigger async event that score has been updated and now displayed
+					target.appendJavaScript(String.format("$('#%s').trigger('scoreupdated.sakai')", this.getMarkupId()));
 
 					refreshNotifications();
 				}
@@ -298,9 +301,14 @@ public class GradeItemCellPanel extends Panel {
 			};
 
 			gradeCell.setType(String.class);
-						
+			gradeCell.add(new AjaxEventBehavior("scoreupdated.sakai") {
+				@Override
+				protected void onEvent(AjaxRequestTarget target) {
+					send(getPage(), Broadcast.BREADTH, new ScoreChangedEvent(studentUuid, categoryId, target));
+				}
+			});
 			gradeCell.setOutputMarkupId(true);
-						
+
 			add(gradeCell);
 		}
 


### PR DESCRIPTION
Setup an async call so the grade and category average are calculated and then refreshed on the screen off the update critical path of updating a grade.

I did notice that the course grade was returning `null` if `isCourseGradeDisplayed == false`. Perhaps we need another endpoint or a mechanism to bypass this constraint in the gradebook service - `GradebookServiceHibernateImpl >> getCourseGradeForStudent`:

```
//if not released, don't do any work
if(!gradebook.isCourseGradeDisplayed()){
    return rval;
}
```

This is a partial solution for #281.  We still need to improve the latency when entering edit mode.
